### PR TITLE
rename repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,15 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(zen_remote_display_system LANGUAGES C CXX VERSION 0.1.0.3)
+project(zen_remote LANGUAGES C CXX VERSION 0.1.0.3)
 
 set (CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set (required_version ${REQUIRED_ZEN_REMOTE_DISPLAY_SYSTEM_VERSION})
+set (required_version ${REQUIRED_ZEN_REMOTE_VERSION})
 
 if(required_version AND (required_version VERSION_GREATER PROJECT_VERSION))
   message(
     FATAL_ERROR 
-    "ZEN Remote Display System is required to be version ${required_version}, \
+    "ZEN Remote is required to be version ${required_version}, \
 but is ${PROJECT_VERSION}"
     )
 endif()

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
-== Remote Display System for ZEN
+== ZEN Remote
 
-A display system that displays an immersive space on a head-mounted display over
-a network.
+Library for ZEN to work with devices such as head-mounted displays and
+controllers over the network.
 
 This project will generate libraries for each of the client and server (ZEN).
 The client may run on Android, so the library for the client must be able to 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,5 +8,5 @@ add_executable(
 
 target_link_libraries(
   test-client
-  PRIVATE zen_remote_display_system_client
+  PRIVATE zen_remote_client
 )

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -2,23 +2,23 @@ file(GLOB_RECURSE CLIENT_SOURCE CONFIGURE_DEPENDS ./*.cc)
 file(GLOB_RECURSE CORE_SOURCE CONFIGURE_DEPENDS ../core/*.cc)
 
 add_library(
-    zen_remote_display_system_client STATIC 
+    zen_remote_client STATIC 
     ${CLIENT_SOURCE}
     ${CORE_SOURCE}
 )
 
 target_include_directories(
-    zen_remote_display_system_client
+    zen_remote_client
     PUBLIC ${public_inc}
     PRIVATE ${private_inc}
     PRIVATE ${boost_headers_content_SOURCE_DIR}/include
 )
 
-target_precompile_headers(zen_remote_display_system_client PRIVATE ../pch/pch.h)
+target_precompile_headers(zen_remote_client PRIVATE ../pch/pch.h)
 
 target_compile_options(
-    zen_remote_display_system_client
+    zen_remote_client
     PRIVATE -Wno-gnu-zero-variadic-macro-arguments
 )
 
-add_library(zen_remote_display_system::client ALIAS zen_remote_display_system_client)
+add_library(zen_remote::client ALIAS zen_remote_client)

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -2,23 +2,23 @@ file(GLOB_RECURSE SERVER_SOURCE CONFIGURE_DEPENDS ./*.cc)
 file(GLOB_RECURSE CORE_SOURCE CONFIGURE_DEPENDS ../core/*.cc)
 
 add_library(
-    zen_remote_display_system_server STATIC 
+    zen_remote_server STATIC 
     ${SERVER_SOURCE}
     ${CORE_SOURCE}
 )
 
 target_include_directories(
-    zen_remote_display_system_server
+    zen_remote_server
     PUBLIC ${public_inc}
     PRIVATE ${private_inc}
     PRIVATE ${boost_headers_content_SOURCE_DIR}/include
 )
 
-target_precompile_headers(zen_remote_display_system_server PRIVATE ../pch/pch.h)
+target_precompile_headers(zen_remote_server PRIVATE ../pch/pch.h)
 
 target_compile_options(
-    zen_remote_display_system_server
+    zen_remote_server
     PRIVATE -Wno-gnu-zero-variadic-macro-arguments
 )
 
-add_library(zen_remote_display_system::server ALIAS zen_remote_display_system_server)
+add_library(zen_remote::server ALIAS zen_remote_server)


### PR DESCRIPTION
## Context

Repository renamed: `zen-remote-display-system` → `zen-remote`.
We will not limit the usage of this repository only for output (display system), but input (controller, eye tracing etc).

## Summary

- [x] fix README
- [x] fix CMake variable names 

## How to check behavior
