### PR TITLE
add build test [CI]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @zigen-project/zigen-maintainers

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,37 @@
+name: build_test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-with-cmake:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: Build
+        run: |
+          mkdir -p build
+          cd build
+          cmake ..
+          make -j
+
+  build-with-meson:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install meson & ninja
+        run: pip install meson ninja
+      
+      - name: Build
+        run: |
+          meson build
+          ninja -C build


### PR DESCRIPTION
## Context

We have both cmake and meson build system.
We are strongly recommended to have CI to check both build systems work.

## Summary

Add build test for both build system.

## How to check behavior

Check that CI passes