### PR TITLE
Gl buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(
   LANGUAGES C CXX
   HOMEPAGE_URL https://github.com/zigen-project/zen-remote
   DESCRIPTION "Library for ZEN to communicate with devices over a network"
-  VERSION 0.1.0.6
+  VERSION 0.1.0.7
 )
 
 if (EXISTS local.cmake)

--- a/include/zen-remote/client/gl-buffer.h
+++ b/include/zen-remote/client/gl-buffer.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace zen::remote::client {
+
+struct IGlBuffer {
+  virtual ~IGlBuffer() = default;
+};
+
+}  // namespace zen::remote::client

--- a/include/zen-remote/client/remote.h
+++ b/include/zen-remote/client/remote.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <memory>
+#include <zen-remote/client/resource-pool.h>
+#include <zen-remote/loop.h>
 
-#include "zen-remote/client/resource-pool.h"
-#include "zen-remote/loop.h"
+#include <memory>
 
 namespace zen::remote::client {
 
@@ -14,7 +14,7 @@ struct IRemote {
 
   virtual void Stop() = 0;
 
-  virtual std::shared_ptr<IResourcePool> pool() = 0;
+  virtual IResourcePool* pool() = 0;
 };
 
 std::unique_ptr<IRemote> CreateRemote(std::unique_ptr<ILoop> loop);

--- a/include/zen-remote/client/rendering-unit.h
+++ b/include/zen-remote/client/rendering-unit.h
@@ -3,7 +3,7 @@
 namespace zen::remote::client {
 
 struct IRenderingUnit {
-  ~IRenderingUnit() = default;
+  virtual ~IRenderingUnit() = default;
 };
 
 }  // namespace zen::remote::client

--- a/include/zen-remote/client/resource-pool.h
+++ b/include/zen-remote/client/resource-pool.h
@@ -1,17 +1,15 @@
 #pragma once
 
-#include <zen-remote/client/rendering-unit.h>
+#include <zen-remote/client/virtual-object.h>
 
 #include <functional>
-#include <memory>
 
 namespace zen::remote::client {
 
 struct IResourcePool {
   virtual ~IResourcePool() = default;
 
-  virtual void ForEachRenderingUnit(
-      std::function<void(IRenderingUnit*)> func) = 0;
+  virtual void Traverse(std::function<void(IVirtualObject*)> func) = 0;
 };
 
 }  // namespace zen::remote::client

--- a/include/zen-remote/client/resource-pool.h
+++ b/include/zen-remote/client/resource-pool.h
@@ -8,7 +8,7 @@
 namespace zen::remote::client {
 
 struct IResourcePool {
-  ~IResourcePool() = default;
+  virtual ~IResourcePool() = default;
 
   virtual void ForEachRenderingUnit(
       std::function<void(IRenderingUnit*)> func) = 0;

--- a/include/zen-remote/client/resource-pool.h
+++ b/include/zen-remote/client/resource-pool.h
@@ -11,7 +11,7 @@ struct IResourcePool {
   ~IResourcePool() = default;
 
   virtual void ForEachRenderingUnit(
-      std::function<void(std::shared_ptr<IRenderingUnit>&)> func) = 0;
+      std::function<void(IRenderingUnit*)> func) = 0;
 };
 
 }  // namespace zen::remote::client

--- a/include/zen-remote/client/virtual-object.h
+++ b/include/zen-remote/client/virtual-object.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <zen-remote/client/rendering-unit.h>
+
+#include <functional>
+
+namespace zen::remote::client {
+
+struct IVirtualObject {
+  virtual ~IVirtualObject() = default;
+
+  virtual void ForEachRenderingUnit(
+      std::function<void(IRenderingUnit*)> func) = 0;
+};
+
+}  // namespace zen::remote::client

--- a/include/zen-remote/server/gl-buffer.h
+++ b/include/zen-remote/server/gl-buffer.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <zen-remote/server/remote.h>
+
+#include <memory>
+
+namespace zen::remote::server {
+
+struct IGlBuffer {
+  virtual ~IGlBuffer() = default;
+
+  virtual uint64_t id() = 0;
+};
+
+std::unique_ptr<IGlBuffer> CreateGlBuffer(std::shared_ptr<IRemote> remote);
+
+}  // namespace zen::remote::server

--- a/include/zen-remote/server/remote.h
+++ b/include/zen-remote/server/remote.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <memory>
+#include <zen-remote/loop.h>
 
-#include "zen-remote/loop.h"
+#include <memory>
 
 namespace zen::remote::server {
 

--- a/include/zen-remote/server/rendering-unit.h
+++ b/include/zen-remote/server/rendering-unit.h
@@ -8,6 +8,12 @@ namespace zen::remote::server {
 
 struct IRenderingUnit {
   virtual ~IRenderingUnit() = default;
+  virtual void Commit() = 0;
+  virtual void GlEnableVertexAttribArray(uint32_t index) = 0;
+  virtual void GlDisableVertexAttribArray(uint32_t index) = 0;
+  virtual void GlVertexAttribPointer(uint32_t index, uint64_t buffer_id,
+      int32_t size, uint64_t type, bool normalized, int32_t stride,
+      uint64_t offset) = 0;
 };
 
 std::unique_ptr<IRenderingUnit> CreateRenderingUnit(

--- a/include/zen-remote/server/rendering-unit.h
+++ b/include/zen-remote/server/rendering-unit.h
@@ -8,7 +8,6 @@ namespace zen::remote::server {
 
 struct IRenderingUnit {
   virtual ~IRenderingUnit() = default;
-  virtual void Commit() = 0;
   virtual void GlEnableVertexAttribArray(uint32_t index) = 0;
   virtual void GlDisableVertexAttribArray(uint32_t index) = 0;
   virtual void GlVertexAttribPointer(uint32_t index, uint64_t buffer_id,
@@ -17,6 +16,6 @@ struct IRenderingUnit {
 };
 
 std::unique_ptr<IRenderingUnit> CreateRenderingUnit(
-    std::shared_ptr<IRemote> remote);
+    std::shared_ptr<IRemote> remote, uint64_t virtual_object_id);
 
 }  // namespace zen::remote::server

--- a/include/zen-remote/server/rendering-unit.h
+++ b/include/zen-remote/server/rendering-unit.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <memory>
+#include <zen-remote/server/remote.h>
 
-#include "remote.h"
+#include <memory>
 
 namespace zen::remote::server {
 

--- a/include/zen-remote/server/virtual-object.h
+++ b/include/zen-remote/server/virtual-object.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <zen-remote/server/remote.h>
+
+#include <memory>
+
+namespace zen::remote::server {
+
+struct IVirtualObject {
+  virtual ~IVirtualObject() = default;
+
+  virtual uint64_t id() = 0;
+};
+
+std::unique_ptr<IVirtualObject> CreateVirtualObject(
+    std::shared_ptr<IRemote> remote);
+
+}  // namespace zen::remote::server

--- a/include/zen-remote/server/virtual-object.h
+++ b/include/zen-remote/server/virtual-object.h
@@ -9,6 +9,8 @@ namespace zen::remote::server {
 struct IVirtualObject {
   virtual ~IVirtualObject() = default;
 
+  virtual void Commit() = 0;
+
   virtual uint64_t id() = 0;
 };
 

--- a/protos/CMakeLists.txt
+++ b/protos/CMakeLists.txt
@@ -20,7 +20,11 @@ message(STATUS "grpc_cpp_plugin: ${ZEN_REMOTE_GRPC_CPP_PLUGIN_EXECUTABLE}")
 
 add_library(zen_remote_grpc_proto STATIC)
 
-set(protos "rendering-unit" "common")
+set(protos
+  "common"
+  "gl-buffer"
+  "rendering-unit"
+)
 
 foreach(proto IN LISTS protos)
 

--- a/protos/CMakeLists.txt
+++ b/protos/CMakeLists.txt
@@ -24,6 +24,7 @@ set(protos
   "common"
   "gl-buffer"
   "rendering-unit"
+  "virtual-object"
 )
 
 foreach(proto IN LISTS protos)

--- a/protos/gl-buffer.proto
+++ b/protos/gl-buffer.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package zen.remote;
+
+import "common.proto";
+
+service GlBufferService
+{
+  rpc New(NewResourceRequest) returns (EmptyResponse);
+  rpc Delete(DeleteResourceRequest) returns (EmptyResponse);
+}

--- a/protos/rendering-unit.proto
+++ b/protos/rendering-unit.proto
@@ -8,4 +8,44 @@ service RenderingUnitService
 {
   rpc New(NewResourceRequest) returns (EmptyResponse);
   rpc Delete(DeleteResourceRequest) returns (EmptyResponse);
+
+  rpc Commit(RenderingUnitCommitRequest) returns (EmptyResponse);
+
+  rpc GlEnableVertexAttribArray(GlEnableVertexAttribArrayRequest)
+      returns (EmptyResponse);
+
+  rpc GlDisableVertexAttribArray(GlDisableVertexAttribArrayRequest)
+      returns (EmptyResponse);
+
+  rpc GlVertexAttribPointer(GlVertexAttribPointerRequest)
+      returns (EmptyResponse);
+}
+
+message RenderingUnitCommitRequest
+{
+  uint64 id = 1;
+};
+
+message GlEnableVertexAttribArrayRequest
+{
+  uint64 id = 1;
+  uint32 index = 2;
+}
+
+message GlDisableVertexAttribArrayRequest
+{
+  uint64 id = 1;
+  uint32 index = 2;
+}
+
+message GlVertexAttribPointerRequest
+{
+  uint64 id = 1;
+  uint32 index = 2;
+  uint64 buffer_id = 3;
+  int32 size = 4;
+  uint64 type = 5;
+  bool normalized = 6;
+  int32 stride = 7;
+  uint64 offset = 8;
 }

--- a/protos/rendering-unit.proto
+++ b/protos/rendering-unit.proto
@@ -6,10 +6,9 @@ import "common.proto";
 
 service RenderingUnitService
 {
-  rpc New(NewResourceRequest) returns (EmptyResponse);
-  rpc Delete(DeleteResourceRequest) returns (EmptyResponse);
+  rpc New(NewRenderingUnitRequest) returns (EmptyResponse);
 
-  rpc Commit(RenderingUnitCommitRequest) returns (EmptyResponse);
+  rpc Delete(DeleteResourceRequest) returns (EmptyResponse);
 
   rpc GlEnableVertexAttribArray(GlEnableVertexAttribArrayRequest)
       returns (EmptyResponse);
@@ -21,10 +20,11 @@ service RenderingUnitService
       returns (EmptyResponse);
 }
 
-message RenderingUnitCommitRequest
+message NewRenderingUnitRequest
 {
   uint64 id = 1;
-};
+  uint64 virtual_object_id = 2;
+}
 
 message GlEnableVertexAttribArrayRequest
 {

--- a/protos/virtual-object.proto
+++ b/protos/virtual-object.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package zen.remote;
+
+import "common.proto";
+
+service VirtualObjectService
+{
+  rpc New(NewResourceRequest) returns (EmptyResponse);
+
+  rpc Delete(DeleteResourceRequest) returns (EmptyResponse);
+
+  rpc Commit(VirtualObjectCommitRequest) returns (EmptyResponse);
+}
+
+message VirtualObjectCommitRequest
+{
+  uint64 id = 1;
+}

--- a/src/client/atomic-command-queue.cc
+++ b/src/client/atomic-command-queue.cc
@@ -1,0 +1,63 @@
+#include "client/atomic-command-queue.h"
+
+namespace zen::remote::client {
+
+void
+AtomicCommandQueue::Push(std::unique_ptr<Command> command)
+{
+  std::lock_guard<std::mutex> lock(mtx_);
+  queue_.emplace_back(std::move(command), false);
+}
+
+void
+AtomicCommandQueue::Commit()
+{
+  std::lock_guard<std::mutex> lock(mtx_);
+  commit_count_++;
+  queue_.emplace_back(std::unique_ptr<Command>(), true);
+}
+
+bool
+AtomicCommandQueue::ExecuteOnce()
+{
+  std::lock_guard<std::mutex> exec_lock(exec_mtx_);
+
+  if (commit_count() == 0) {
+    return false;
+  }
+
+  std::unique_lock<std::mutex> lock(mtx_);
+
+  while (true) {
+    if (queue_.front().is_commit_command) {
+      commit_count_--;
+      queue_.pop_front();
+      return true;
+    }
+
+    auto &command = queue_.front().command;
+
+    lock.unlock();
+
+    command->Execute();
+
+    lock.lock();
+
+    queue_.pop_front();
+  }
+}
+
+size_t
+AtomicCommandQueue::commit_count()
+{
+  std::lock_guard<std::mutex> lock(mtx_);
+  return commit_count_;
+}
+
+AtomicCommandQueue::CommandInfo::CommandInfo(
+    std::unique_ptr<Command> command, bool is_commit_command)
+    : command(std::move(command)), is_commit_command(is_commit_command)
+{
+}
+
+}  // namespace zen::remote::client

--- a/src/client/atomic-command-queue.h
+++ b/src/client/atomic-command-queue.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "client/command.h"
+#include "core/common.h"
+
+namespace zen::remote::client {
+
+/**
+ * Push multiple commands and commit them. This handles those commands
+ * atomically. The pushed commands will not be executed until they are
+ * committed. All methods can be called from multiple threads.
+ */
+class AtomicCommandQueue {
+ public:
+  DISABLE_MOVE_AND_COPY(AtomicCommandQueue);
+  AtomicCommandQueue() = default;
+
+  void Push(std::unique_ptr<Command> command);
+
+  void Commit();
+
+  /**
+   * Execute one set of commands.
+   */
+  bool ExecuteOnce();
+
+  size_t commit_count();
+
+ private:
+  struct CommandInfo {
+    CommandInfo(std::unique_ptr<Command> command, bool is_commit_command);
+
+    std::unique_ptr<Command> command;  // empty if is_commit_command == true
+    bool is_commit_command;
+  };
+
+  std::list<CommandInfo> queue_;
+  size_t commit_count_;
+  std::mutex mtx_;  // lock queue_ and commit_count_;
+
+  std::mutex exec_mtx_;
+};
+
+}  // namespace zen::remote::client

--- a/src/client/command.cc
+++ b/src/client/command.cc
@@ -1,0 +1,13 @@
+#include "client/command.h"
+
+namespace zen::remote::client {
+
+Command::Command(std::function<void()> executer) : executer_(executer) {}
+
+void
+Command::Execute()
+{
+  executer_();
+}
+
+}  // namespace zen::remote::client

--- a/src/client/command.h
+++ b/src/client/command.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "core/common.h"
+
+namespace zen::remote::client {
+
+class Command {
+ public:
+  DISABLE_MOVE_AND_COPY(Command);
+  Command(std::function<void()> executer);
+
+  void Execute();
+
+ private:
+  const std::function<void()> executer_;
+};
+
+}  // namespace zen::remote::client

--- a/src/client/gl-buffer.cc
+++ b/src/client/gl-buffer.cc
@@ -4,6 +4,12 @@ namespace zen::remote::client {
 
 GlBuffer::GlBuffer(uint64_t id) : id_(id) {}
 
+void
+GlBuffer::Commit()
+{
+  // TODO: commit pending state
+}
+
 uint64_t
 GlBuffer::id()
 {

--- a/src/client/gl-buffer.cc
+++ b/src/client/gl-buffer.cc
@@ -1,0 +1,13 @@
+#include "client/gl-buffer.h"
+
+namespace zen::remote::client {
+
+GlBuffer::GlBuffer(uint64_t id) : id_(id) {}
+
+uint64_t
+GlBuffer::id()
+{
+  return id_;
+}
+
+}  // namespace zen::remote::client

--- a/src/client/gl-buffer.h
+++ b/src/client/gl-buffer.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "client/resource.h"
+#include "core/common.h"
+#include "zen-remote/client/gl-buffer.h"
+
+namespace zen::remote::client {
+
+class GlBuffer final : public IGlBuffer, public IResource {
+ public:
+  DISABLE_MOVE_AND_COPY(GlBuffer);
+  GlBuffer() = delete;
+  GlBuffer(uint64_t id);
+
+  uint64_t id() override;
+
+ private:
+  const uint64_t id_;
+};
+
+}  // namespace zen::remote::client

--- a/src/client/gl-buffer.h
+++ b/src/client/gl-buffer.h
@@ -12,6 +12,9 @@ class GlBuffer final : public IGlBuffer, public IResource {
   GlBuffer() = delete;
   GlBuffer(uint64_t id);
 
+  /** Used in the update thread */
+  void Commit();
+
   uint64_t id() override;
 
  private:

--- a/src/client/grpc-server.cc
+++ b/src/client/grpc-server.cc
@@ -2,6 +2,7 @@
 
 #include "client/service/gl-buffer.h"
 #include "client/service/rendering-unit.h"
+#include "client/service/virtual-object.h"
 
 namespace zen::remote::client {
 
@@ -19,11 +20,13 @@ GrpcServer::Start()
 
     builder.AddListeningPort(host_port, grpc::InsecureServerCredentials());
 
-    service::RenderingUnitServiceImpl rendering_unit_service(pool_);
     service::GlBufferServiceImpl gl_buffer_service(pool_);
+    service::RenderingUnitServiceImpl rendering_unit_service(pool_);
+    service::VirtualObjectServiceImpl virtual_object_service(pool_);
 
-    builder.RegisterService(&rendering_unit_service);
     builder.RegisterService(&gl_buffer_service);
+    builder.RegisterService(&rendering_unit_service);
+    builder.RegisterService(&virtual_object_service);
 
     server_ = builder.BuildAndStart();
     server_->Wait();

--- a/src/client/grpc-server.cc
+++ b/src/client/grpc-server.cc
@@ -1,5 +1,6 @@
 #include "client/grpc-server.h"
 
+#include "client/service/gl-buffer.h"
 #include "client/service/rendering-unit.h"
 
 namespace zen::remote::client {
@@ -19,8 +20,10 @@ GrpcServer::Start()
     builder.AddListeningPort(host_port, grpc::InsecureServerCredentials());
 
     service::RenderingUnitServiceImpl rendering_unit_service(pool_);
+    service::GlBufferServiceImpl gl_buffer_service(pool_);
 
     builder.RegisterService(&rendering_unit_service);
+    builder.RegisterService(&gl_buffer_service);
 
     server_ = builder.BuildAndStart();
     server_->Wait();

--- a/src/client/grpc-server.cc
+++ b/src/client/grpc-server.cc
@@ -1,9 +1,13 @@
 #include "client/grpc-server.h"
 
 #include "client/service/rendering-unit.h"
-#include "core/logger.h"
 
 namespace zen::remote::client {
+
+GrpcServer::GrpcServer(std::string host, uint16_t port, ResourcePool *pool)
+    : host_(host), port_(port), pool_(pool)
+{
+}
 
 void
 GrpcServer::Start()

--- a/src/client/grpc-server.h
+++ b/src/client/grpc-server.h
@@ -1,19 +1,17 @@
 #pragma once
 
-#include "client/resource-pool.h"
 #include "core/common.h"
 
 namespace zen::remote::client {
+
+class ResourcePool;
 
 class GrpcServer {
  public:
   DISABLE_MOVE_AND_COPY(GrpcServer);
   GrpcServer() = delete;
-  GrpcServer(
-      std::string host, uint16_t port, std::shared_ptr<ResourcePool> pool)
-      : host_(host), port_(port), pool_(std::move(pool))
-  {
-  }
+  GrpcServer(std::string host, uint16_t port, ResourcePool *pool);
+
   ~GrpcServer();
 
   void Start();
@@ -23,7 +21,8 @@ class GrpcServer {
   const uint16_t port_;
   std::thread thread_;
   std::unique_ptr<grpc::Server> server_;
-  std::shared_ptr<ResourcePool> pool_;
+
+  ResourcePool *pool_;
 };
 
 }  // namespace zen::remote::client

--- a/src/client/remote.cc
+++ b/src/client/remote.cc
@@ -1,11 +1,15 @@
 #include "client/remote.h"
 
-#include "core/common.h"
+#include "client/grpc-server.h"
 #include "core/connection/peer.h"
 #include "core/logger.h"
-#include "zen-remote/client/remote.h"
 
 namespace zen::remote::client {
+
+Remote::Remote(std::unique_ptr<ILoop> loop)
+    : context_(std::make_unique<Context>(std::move(loop)))
+{
+}
 
 void
 Remote::Start()
@@ -18,7 +22,8 @@ Remote::Start()
   });
   peer_->StartDiscover();
 
-  grpc_server_ = std::make_unique<GrpcServer>("0.0.0.0", kGrpcPort, pool_);
+  grpc_server_ =
+      std::make_unique<GrpcServer>("0.0.0.0", kGrpcPort, &this->pool_);
   grpc_server_->Start();
 }
 
@@ -28,10 +33,10 @@ Remote::Stop()
   // TODO:
 }
 
-std::shared_ptr<IResourcePool>
+IResourcePool*
 Remote::pool()
 {
-  return pool_;
+  return &pool_;
 }
 
 std::unique_ptr<IRemote>

--- a/src/client/remote.h
+++ b/src/client/remote.h
@@ -1,32 +1,35 @@
 #pragma once
 
-#include "client/grpc-server.h"
 #include "client/resource-pool.h"
-#include "core/connection/peer.h"
+#include "core/common.h"
 #include "core/context.h"
 #include "zen-remote/client/remote.h"
 
+namespace zen::remote::connection {
+class Peer;
+}
+
 namespace zen::remote::client {
+
+class GrpcServer;
 
 class Remote : public IRemote {
  public:
-  Remote(std::unique_ptr<ILoop> loop)
-      : context_(std::make_unique<Context>(std::move(loop))),
-        pool_(std::make_shared<ResourcePool>())
-  {
-  }
+  DISABLE_MOVE_AND_COPY(Remote);
+  Remote() = delete;
+  Remote(std::unique_ptr<ILoop> loop);
 
   void Start() override;
 
   void Stop() override;
 
-  std::shared_ptr<IResourcePool> pool() override;
+  IResourcePool* pool() override;
 
  private:
   std::unique_ptr<connection::Peer> peer_;
   std::shared_ptr<Context> context_;
   std::unique_ptr<GrpcServer> grpc_server_;
-  std::shared_ptr<ResourcePool> pool_;
+  ResourcePool pool_;
 };
 
 }  // namespace zen::remote::client

--- a/src/client/rendering-unit.cc
+++ b/src/client/rendering-unit.cc
@@ -1,13 +1,77 @@
 #include "client/rendering-unit.h"
 
+#include "client/atomic-command-queue.h"
+#include "client/gl-buffer.h"
+
 namespace zen::remote::client {
 
-RenderingUnit::RenderingUnit(uint64_t id) : id_(id) {}
+RenderingUnit::RenderingUnit(
+    uint64_t id, AtomicCommandQueue* update_rendering_queue)
+    : id_(id), update_rendering_queue_(update_rendering_queue)
+{
+}
+
+void
+RenderingUnit::Commit()
+{
+  for (auto& vertex_attrib : pending_.vertex_attribs) {
+    if (auto gl_buffer = vertex_attrib.second.gl_buffer.lock()) {
+      gl_buffer->Commit();
+    }
+  }
+
+  // TODO: commit pending state
+}
+
+void
+RenderingUnit::GlEnableVertexAttribArray(uint32_t index)
+{
+  auto result = pending_.vertex_attribs.find(index);
+
+  if (result != pending_.vertex_attribs.end()) {
+    (*result).second.enabled = true;
+  } else {
+    pending_.vertex_attribs.emplace(std::piecewise_construct,
+        std::forward_as_tuple(index), std::forward_as_tuple(index));
+  }
+}
+
+void
+RenderingUnit::GlDisableVertexAttribArray(uint32_t index)
+{
+  auto result = pending_.vertex_attribs.find(index);
+  if (result == pending_.vertex_attribs.end()) return;
+
+  (*result).second.enabled = false;
+}
+
+void
+RenderingUnit::GlVertexAttribPointer(uint32_t index,
+    std::weak_ptr<GlBuffer> gl_buffer, int32_t size, uint64_t type,
+    bool normalized, int32_t stride, uint64_t offset)
+{
+  auto result = pending_.vertex_attribs.find(index);
+  if (result == pending_.vertex_attribs.end()) return;
+
+  (*result).second.index = index;
+  (*result).second.gl_buffer = gl_buffer;
+  (*result).second.size = size;
+  (*result).second.type = type;
+  (*result).second.normalized = normalized;
+  (*result).second.stride = stride;
+  (*result).second.offset = offset;
+  (*result).second.filled = true;
+}
 
 uint64_t
 RenderingUnit::id()
 {
   return id_;
+}
+
+RenderingUnit::VertexAttrib::VertexAttrib(uint32_t index)
+    : index(index), enabled(true), filled(false)
+{
 }
 
 }  // namespace zen::remote::client

--- a/src/client/rendering-unit.cc
+++ b/src/client/rendering-unit.cc
@@ -2,6 +2,8 @@
 
 namespace zen::remote::client {
 
+RenderingUnit::RenderingUnit(uint64_t id) : id_(id) {}
+
 uint64_t
 RenderingUnit::id()
 {

--- a/src/client/rendering-unit.h
+++ b/src/client/rendering-unit.h
@@ -6,16 +6,56 @@
 
 namespace zen::remote::client {
 
+class GlBuffer;
+class AtomicCommandQueue;
+
 class RenderingUnit final : public IRenderingUnit, public IResource {
  public:
   DISABLE_MOVE_AND_COPY(RenderingUnit);
   RenderingUnit() = delete;
-  RenderingUnit(uint64_t id);
+  RenderingUnit(uint64_t id, AtomicCommandQueue *update_rendering_queue);
+
+  /** Used in the update thread */
+  void Commit();
+
+  /** Used in the update thread */
+  void GlEnableVertexAttribArray(uint32_t index);
+
+  /** Used in the update thread */
+  void GlDisableVertexAttribArray(uint32_t index);
+
+  /** Used in the update thread */
+  void GlVertexAttribPointer(uint32_t index, std::weak_ptr<GlBuffer> gl_buffer,
+      int32_t size, uint64_t type, bool normalized, int32_t stride,
+      uint64_t offset);
 
   uint64_t id() override;
 
  private:
+  struct VertexAttrib {
+    VertexAttrib(uint32_t index);
+
+    uint64_t type;
+    uint64_t offset;
+    uint32_t index;
+    int32_t size;
+    int32_t stride;
+    std::weak_ptr<GlBuffer> gl_buffer;
+    bool normalized;
+    bool enabled;
+    bool filled;
+  };
+
   const uint64_t id_;
+  AtomicCommandQueue *update_rendering_queue_;
+
+  struct {
+    std::unordered_map<uint32_t, VertexAttrib> vertex_attribs;
+  } pending_;
+
+  struct {
+    // TODO:
+  } rendering_;
 };
 
 }  // namespace zen::remote::client

--- a/src/client/rendering-unit.h
+++ b/src/client/rendering-unit.h
@@ -16,8 +16,6 @@ class RenderingUnit final : public IRenderingUnit, public IResource {
 
  private:
   const uint64_t id_;
-  bool commited_ = false;  // false until the first commit
-  bool update_ = false;    // true when pending changes need to be applied
 };
 
 }  // namespace zen::remote::client

--- a/src/client/rendering-unit.h
+++ b/src/client/rendering-unit.h
@@ -10,7 +10,7 @@ class RenderingUnit final : public IRenderingUnit, public IResource {
  public:
   DISABLE_MOVE_AND_COPY(RenderingUnit);
   RenderingUnit() = delete;
-  RenderingUnit(uint64_t id) : id_(id){};
+  RenderingUnit(uint64_t id);
 
   uint64_t id() override;
 

--- a/src/client/resource-pool.cc
+++ b/src/client/resource-pool.cc
@@ -5,13 +5,10 @@
 namespace zen::remote::client {
 
 void
-ResourcePool::ForEachRenderingUnit(
-    std::function<void(std::shared_ptr<IRenderingUnit>&)> func)
+ResourcePool::ForEachRenderingUnit(std::function<void(IRenderingUnit*)> func)
 {
-  rendering_units_->ForEach([func](const std::shared_ptr<RenderingUnit>& unit) {
-    auto u = std::dynamic_pointer_cast<IRenderingUnit>(unit);
-    func(u);
-  });
+  rendering_units_.ForEach(
+      [func](const std::shared_ptr<RenderingUnit> unit) { func(unit.get()); });
 }
 
 }  // namespace zen::remote::client

--- a/src/client/resource-pool.cc
+++ b/src/client/resource-pool.cc
@@ -5,10 +5,11 @@
 namespace zen::remote::client {
 
 void
-ResourcePool::ForEachRenderingUnit(std::function<void(IRenderingUnit*)> func)
+ResourcePool::Traverse(std::function<void(IVirtualObject *)> func)
 {
-  rendering_units_.ForEach(
-      [func](const std::shared_ptr<RenderingUnit> unit) { func(unit.get()); });
+  virtual_objects_.ForEach(
+      [func](const std::shared_ptr<VirtualObject> virtual_object) {
+        func(virtual_object.get());
+      });
 }
-
 }  // namespace zen::remote::client

--- a/src/client/resource-pool.cc
+++ b/src/client/resource-pool.cc
@@ -7,6 +7,12 @@ namespace zen::remote::client {
 void
 ResourcePool::Traverse(std::function<void(IVirtualObject *)> func)
 {
+  auto execute_count = update_rendering_queue_.commit_count();
+
+  for (unsigned int i = 0; i < execute_count; i++) {
+    if (update_rendering_queue_.ExecuteOnce() == false) break;
+  }
+
   virtual_objects_.ForEach(
       [func](const std::shared_ptr<VirtualObject> virtual_object) {
         func(virtual_object.get());

--- a/src/client/resource-pool.h
+++ b/src/client/resource-pool.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "client/gl-buffer.h"
 #include "client/rendering-unit.h"
 #include "client/resource-container.h"
 #include "core/common.h"
@@ -10,6 +11,9 @@ namespace zen::remote::client {
 using RenderingUnitContainer =
     ResourceContainer<RenderingUnit, ResourceContainerType::kLoopIntensive>;
 
+using GlBufferContainer =
+    ResourceContainer<GlBuffer, ResourceContainerType::kFindByIdIntensive>;
+
 class ResourcePool final : public IResourcePool {
  public:
   DISABLE_MOVE_AND_COPY(ResourcePool);
@@ -19,15 +23,23 @@ class ResourcePool final : public IResourcePool {
       std::function<void(IRenderingUnit *)> func) override;
 
   inline RenderingUnitContainer *rendering_units();
+  inline GlBufferContainer *gl_buffers();
 
  private:
   RenderingUnitContainer rendering_units_;
+  GlBufferContainer gl_buffers_;
 };
 
 inline RenderingUnitContainer *
 ResourcePool::rendering_units()
 {
   return &rendering_units_;
+}
+
+inline GlBufferContainer *
+ResourcePool::gl_buffers()
+{
+  return &gl_buffers_;
 }
 
 }  // namespace zen::remote::client

--- a/src/client/resource-pool.h
+++ b/src/client/resource-pool.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "client/atomic-command-queue.h"
 #include "client/gl-buffer.h"
 #include "client/rendering-unit.h"
 #include "client/resource-container.h"
@@ -18,6 +19,22 @@ using RenderingUnitContainer =
 using GlBufferContainer =
     ResourceContainer<GlBuffer, ResourceContainerType::kFindByIdIntensive>;
 
+/**
+ * @brief Retain all resources
+ *
+ * Resources are updated by the "update thread" and the updated states are
+ * temporarily held in the "pending state" of the respective resource.
+ * When a set of resources are commited, commands to update the "rendering
+ * state" based on the "pending state" are pushed to `update_rendering_queue`.
+ * The pushed commands are executed by the "rendering thread" just before the
+ * resource pool is traversed to render scene. At this time, commands issued in
+ * a single commit are executed atomically, thus maintaining the integrity of
+ * the entire "rendering state".
+ * These commands should not read the pending state, since the pending state may
+ * be updated between when these commands are pushed and when they are executed.
+ * Instead, use a lambda capture or something similar to preserve the state at
+ * the time of commit. This also helps keep multi-threading safe.
+ */
 class ResourcePool final : public IResourcePool {
  public:
   DISABLE_MOVE_AND_COPY(ResourcePool);
@@ -29,10 +46,15 @@ class ResourcePool final : public IResourcePool {
   inline RenderingUnitContainer *rendering_units();
   inline GlBufferContainer *gl_buffers();
 
+  /** Commands to update rendering state of resources */
+  inline AtomicCommandQueue *update_rendering_queue();
+
  private:
   VirtualObjectContainer virtual_objects_;
   RenderingUnitContainer rendering_units_;
   GlBufferContainer gl_buffers_;
+
+  AtomicCommandQueue update_rendering_queue_;
 };
 
 inline VirtualObjectContainer *
@@ -51,6 +73,12 @@ inline GlBufferContainer *
 ResourcePool::gl_buffers()
 {
   return &gl_buffers_;
+}
+
+inline AtomicCommandQueue *
+ResourcePool::update_rendering_queue()
+{
+  return &update_rendering_queue_;
 }
 
 }  // namespace zen::remote::client

--- a/src/client/resource-pool.h
+++ b/src/client/resource-pool.h
@@ -13,23 +13,21 @@ using RenderingUnitContainer =
 class ResourcePool final : public IResourcePool {
  public:
   DISABLE_MOVE_AND_COPY(ResourcePool);
-  ResourcePool() : rendering_units_(std::make_unique<RenderingUnitContainer>())
-  {
-  }
+  ResourcePool() = default;
 
   void ForEachRenderingUnit(
-      std::function<void(std::shared_ptr<IRenderingUnit> &)> func) override;
+      std::function<void(IRenderingUnit *)> func) override;
 
-  inline std::unique_ptr<RenderingUnitContainer> &rendering_units();
+  inline RenderingUnitContainer *rendering_units();
 
  private:
-  std::unique_ptr<RenderingUnitContainer> rendering_units_;
+  RenderingUnitContainer rendering_units_;
 };
 
-inline std::unique_ptr<RenderingUnitContainer> &
+inline RenderingUnitContainer *
 ResourcePool::rendering_units()
 {
-  return rendering_units_;
+  return &rendering_units_;
 }
 
 }  // namespace zen::remote::client

--- a/src/client/resource-pool.h
+++ b/src/client/resource-pool.h
@@ -3,13 +3,17 @@
 #include "client/gl-buffer.h"
 #include "client/rendering-unit.h"
 #include "client/resource-container.h"
+#include "client/virtual-object.h"
 #include "core/common.h"
 #include "zen-remote/client/resource-pool.h"
 
 namespace zen::remote::client {
 
+using VirtualObjectContainer =
+    ResourceContainer<VirtualObject, ResourceContainerType::kLoopIntensive>;
+
 using RenderingUnitContainer =
-    ResourceContainer<RenderingUnit, ResourceContainerType::kLoopIntensive>;
+    ResourceContainer<RenderingUnit, ResourceContainerType::kFindByIdIntensive>;
 
 using GlBufferContainer =
     ResourceContainer<GlBuffer, ResourceContainerType::kFindByIdIntensive>;
@@ -19,16 +23,23 @@ class ResourcePool final : public IResourcePool {
   DISABLE_MOVE_AND_COPY(ResourcePool);
   ResourcePool() = default;
 
-  void ForEachRenderingUnit(
-      std::function<void(IRenderingUnit *)> func) override;
+  void Traverse(std::function<void(IVirtualObject *)> func) override;
 
+  inline VirtualObjectContainer *virtual_objects();
   inline RenderingUnitContainer *rendering_units();
   inline GlBufferContainer *gl_buffers();
 
  private:
+  VirtualObjectContainer virtual_objects_;
   RenderingUnitContainer rendering_units_;
   GlBufferContainer gl_buffers_;
 };
+
+inline VirtualObjectContainer *
+ResourcePool::virtual_objects()
+{
+  return &virtual_objects_;
+}
 
 inline RenderingUnitContainer *
 ResourcePool::rendering_units()

--- a/src/client/resource.h
+++ b/src/client/resource.h
@@ -3,7 +3,7 @@
 namespace zen::remote::client {
 
 struct IResource {
-  ~IResource() = default;
+  virtual ~IResource() = default;
 
   virtual uint64_t id() = 0;
 };

--- a/src/client/service/gl-buffer.cc
+++ b/src/client/service/gl-buffer.cc
@@ -8,15 +8,20 @@ GlBufferServiceImpl::GlBufferServiceImpl(ResourcePool* pool) : pool_(pool) {}
 
 grpc::Status
 GlBufferServiceImpl::New(grpc::ServerContext* /*context*/,
-    const NewResourceRequest* /*request*/, EmptyResponse* /*response*/)
+    const NewResourceRequest* request, EmptyResponse* /*response*/)
 {
+  auto gl_buffer = std::make_unique<GlBuffer>(request->id());
+
+  pool_->gl_buffers()->Add(std::move(gl_buffer));
+
   return grpc::Status::OK;
 }
 
 grpc::Status
 GlBufferServiceImpl::Delete(grpc::ServerContext* /*context*/,
-    const DeleteResourceRequest* /*request*/, EmptyResponse* /*response*/)
+    const DeleteResourceRequest* request, EmptyResponse* /*response*/)
 {
+  pool_->gl_buffers()->ScheduleRemove(request->id());
   return grpc::Status::OK;
 }
 

--- a/src/client/service/gl-buffer.cc
+++ b/src/client/service/gl-buffer.cc
@@ -1,0 +1,23 @@
+#include "client/service/gl-buffer.h"
+
+#include "client/resource-pool.h"
+
+namespace zen::remote::client::service {
+
+GlBufferServiceImpl::GlBufferServiceImpl(ResourcePool* pool) : pool_(pool) {}
+
+grpc::Status
+GlBufferServiceImpl::New(grpc::ServerContext* /*context*/,
+    const NewResourceRequest* /*request*/, EmptyResponse* /*response*/)
+{
+  return grpc::Status::OK;
+}
+
+grpc::Status
+GlBufferServiceImpl::Delete(grpc::ServerContext* /*context*/,
+    const DeleteResourceRequest* /*request*/, EmptyResponse* /*response*/)
+{
+  return grpc::Status::OK;
+}
+
+}  // namespace zen::remote::client::service

--- a/src/client/service/gl-buffer.h
+++ b/src/client/service/gl-buffer.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "core/common.h"
+#include "gl-buffer.grpc.pb.h"
+
+namespace zen::remote::client {
+class ResourcePool;
+}
+
+namespace zen::remote::client::service {
+
+class GlBufferServiceImpl final : public GlBufferService::Service {
+ public:
+  DISABLE_MOVE_AND_COPY(GlBufferServiceImpl);
+  GlBufferServiceImpl() = delete;
+  GlBufferServiceImpl(ResourcePool* pool);
+
+  virtual grpc::Status New(grpc::ServerContext* context,
+      const NewResourceRequest* request, EmptyResponse* response) override;
+
+  virtual grpc::Status Delete(grpc::ServerContext* context,
+      const DeleteResourceRequest* request, EmptyResponse* response) override;
+
+ private:
+  ResourcePool* pool_;
+};
+
+}  // namespace zen::remote::client::service

--- a/src/client/service/rendering-unit.cc
+++ b/src/client/service/rendering-unit.cc
@@ -1,8 +1,13 @@
 #include "client/service/rendering-unit.h"
 
-#include "core/logger.h"
+#include "client/resource-pool.h"
 
 namespace zen::remote::client::service {
+
+RenderingUnitServiceImpl::RenderingUnitServiceImpl(ResourcePool* pool)
+    : pool_(pool)
+{
+}
 
 grpc::Status
 RenderingUnitServiceImpl::New(grpc::ServerContext* /*context*/,

--- a/src/client/service/rendering-unit.cc
+++ b/src/client/service/rendering-unit.cc
@@ -13,7 +13,8 @@ grpc::Status
 RenderingUnitServiceImpl::New(grpc::ServerContext* /*context*/,
     const NewRenderingUnitRequest* request, EmptyResponse* /*response*/)
 {
-  auto rendering_unit = std::make_shared<RenderingUnit>(request->id());
+  auto rendering_unit = std::make_shared<RenderingUnit>(
+      request->id(), pool_->update_rendering_queue());
   auto virtual_object =
       pool_->virtual_objects()->Get(request->virtual_object_id());
 
@@ -35,27 +36,41 @@ RenderingUnitServiceImpl::Delete(grpc::ServerContext* /*context*/,
 grpc::Status
 RenderingUnitServiceImpl::GlEnableVertexAttribArray(
     grpc::ServerContext* /*context*/,
-    const GlEnableVertexAttribArrayRequest* /*request*/,
+    const GlEnableVertexAttribArrayRequest* request,
     EmptyResponse* /*response*/)
 {
+  auto rendering_unit = pool_->rendering_units()->Get(request->id());
+
+  rendering_unit->GlEnableVertexAttribArray(request->index());
+
   return grpc::Status::OK;
 }
 
 grpc::Status
 RenderingUnitServiceImpl::GlDisableVertexAttribArray(
     grpc::ServerContext* /*context*/,
-    const GlDisableVertexAttribArrayRequest* /*request*/,
+    const GlDisableVertexAttribArrayRequest* request,
     EmptyResponse* /*response*/)
 {
+  auto rendering_unit = pool_->rendering_units()->Get(request->id());
+
+  rendering_unit->GlDisableVertexAttribArray(request->index());
+
   return grpc::Status::OK;
 }
 
 grpc::Status
 RenderingUnitServiceImpl::GlVertexAttribPointer(
     grpc::ServerContext* /*context*/,
-    const GlVertexAttribPointerRequest* /*request*/,
-    EmptyResponse* /*response*/)
+    const GlVertexAttribPointerRequest* request, EmptyResponse* /*response*/)
 {
+  auto rendering_unit = pool_->rendering_units()->Get(request->id());
+  auto gl_buffer = pool_->gl_buffers()->Get(request->buffer_id());
+
+  rendering_unit->GlVertexAttribPointer(request->index(), gl_buffer,
+      request->size(), request->type(), request->normalized(),
+      request->stride(), request->offset());
+
   return grpc::Status::OK;
 }
 

--- a/src/client/service/rendering-unit.cc
+++ b/src/client/service/rendering-unit.cc
@@ -11,9 +11,13 @@ RenderingUnitServiceImpl::RenderingUnitServiceImpl(ResourcePool* pool)
 
 grpc::Status
 RenderingUnitServiceImpl::New(grpc::ServerContext* /*context*/,
-    const NewResourceRequest* request, EmptyResponse* /*response*/)
+    const NewRenderingUnitRequest* request, EmptyResponse* /*response*/)
 {
-  auto rendering_unit = std::make_unique<RenderingUnit>(request->id());
+  auto rendering_unit = std::make_shared<RenderingUnit>(request->id());
+  auto virtual_object =
+      pool_->virtual_objects()->Get(request->virtual_object_id());
+
+  virtual_object->AddRenderingUnit(rendering_unit);
 
   pool_->rendering_units()->Add(std::move(rendering_unit));
 
@@ -25,13 +29,6 @@ RenderingUnitServiceImpl::Delete(grpc::ServerContext* /*context*/,
     const DeleteResourceRequest* request, EmptyResponse* /*response*/)
 {
   pool_->rendering_units()->ScheduleRemove(request->id());
-  return grpc::Status::OK;
-}
-
-grpc::Status
-RenderingUnitServiceImpl::Commit(grpc::ServerContext* /*context*/,
-    const RenderingUnitCommitRequest* /*request*/, EmptyResponse* /*response*/)
-{
   return grpc::Status::OK;
 }
 

--- a/src/client/service/rendering-unit.cc
+++ b/src/client/service/rendering-unit.cc
@@ -28,4 +28,38 @@ RenderingUnitServiceImpl::Delete(grpc::ServerContext* /*context*/,
   return grpc::Status::OK;
 }
 
+grpc::Status
+RenderingUnitServiceImpl::Commit(grpc::ServerContext* /*context*/,
+    const RenderingUnitCommitRequest* /*request*/, EmptyResponse* /*response*/)
+{
+  return grpc::Status::OK;
+}
+
+grpc::Status
+RenderingUnitServiceImpl::GlEnableVertexAttribArray(
+    grpc::ServerContext* /*context*/,
+    const GlEnableVertexAttribArrayRequest* /*request*/,
+    EmptyResponse* /*response*/)
+{
+  return grpc::Status::OK;
+}
+
+grpc::Status
+RenderingUnitServiceImpl::GlDisableVertexAttribArray(
+    grpc::ServerContext* /*context*/,
+    const GlDisableVertexAttribArrayRequest* /*request*/,
+    EmptyResponse* /*response*/)
+{
+  return grpc::Status::OK;
+}
+
+grpc::Status
+RenderingUnitServiceImpl::GlVertexAttribPointer(
+    grpc::ServerContext* /*context*/,
+    const GlVertexAttribPointerRequest* /*request*/,
+    EmptyResponse* /*response*/)
+{
+  return grpc::Status::OK;
+}
+
 }  // namespace zen::remote::client::service

--- a/src/client/service/rendering-unit.h
+++ b/src/client/service/rendering-unit.h
@@ -15,13 +15,29 @@ class RenderingUnitServiceImpl final : public RenderingUnitService::Service {
   RenderingUnitServiceImpl() = delete;
   RenderingUnitServiceImpl(ResourcePool* pool);
 
- private:
   virtual grpc::Status New(grpc::ServerContext* context,
       const NewResourceRequest* request, EmptyResponse* response) override;
 
   virtual grpc::Status Delete(grpc::ServerContext* context,
       const DeleteResourceRequest* request, EmptyResponse* response) override;
 
+  virtual grpc::Status Commit(grpc::ServerContext* context,
+      const RenderingUnitCommitRequest* request,
+      EmptyResponse* response) override;
+
+  virtual grpc::Status GlEnableVertexAttribArray(grpc::ServerContext* context,
+      const GlEnableVertexAttribArrayRequest* request,
+      EmptyResponse* response) override;
+
+  virtual grpc::Status GlDisableVertexAttribArray(grpc::ServerContext* context,
+      const GlDisableVertexAttribArrayRequest* request,
+      EmptyResponse* response) override;
+
+  virtual grpc::Status GlVertexAttribPointer(grpc::ServerContext* context,
+      const GlVertexAttribPointerRequest* request,
+      EmptyResponse* response) override;
+
+ private:
   ResourcePool* pool_;
 };
 

--- a/src/client/service/rendering-unit.h
+++ b/src/client/service/rendering-unit.h
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "client/resource-pool.h"
 #include "core/common.h"
 #include "rendering-unit.grpc.pb.h"
+
+namespace zen::remote::client {
+class ResourcePool;
+}
 
 namespace zen::remote::client::service {
 
@@ -10,8 +13,7 @@ class RenderingUnitServiceImpl final : public RenderingUnitService::Service {
  public:
   DISABLE_MOVE_AND_COPY(RenderingUnitServiceImpl);
   RenderingUnitServiceImpl() = delete;
-  RenderingUnitServiceImpl(std::shared_ptr<ResourcePool> pool)
-      : pool_(std::move(pool)){};
+  RenderingUnitServiceImpl(ResourcePool* pool);
 
  private:
   virtual grpc::Status New(grpc::ServerContext* context,
@@ -20,7 +22,7 @@ class RenderingUnitServiceImpl final : public RenderingUnitService::Service {
   virtual grpc::Status Delete(grpc::ServerContext* context,
       const DeleteResourceRequest* request, EmptyResponse* response) override;
 
-  std::shared_ptr<ResourcePool> pool_;
+  ResourcePool* pool_;
 };
 
 }  // namespace zen::remote::client::service

--- a/src/client/service/rendering-unit.h
+++ b/src/client/service/rendering-unit.h
@@ -16,14 +16,10 @@ class RenderingUnitServiceImpl final : public RenderingUnitService::Service {
   RenderingUnitServiceImpl(ResourcePool* pool);
 
   virtual grpc::Status New(grpc::ServerContext* context,
-      const NewResourceRequest* request, EmptyResponse* response) override;
+      const NewRenderingUnitRequest* request, EmptyResponse* response) override;
 
   virtual grpc::Status Delete(grpc::ServerContext* context,
       const DeleteResourceRequest* request, EmptyResponse* response) override;
-
-  virtual grpc::Status Commit(grpc::ServerContext* context,
-      const RenderingUnitCommitRequest* request,
-      EmptyResponse* response) override;
 
   virtual grpc::Status GlEnableVertexAttribArray(grpc::ServerContext* context,
       const GlEnableVertexAttribArrayRequest* request,

--- a/src/client/service/virtual-object.cc
+++ b/src/client/service/virtual-object.cc
@@ -13,7 +13,8 @@ grpc::Status
 VirtualObjectServiceImpl::New(grpc::ServerContext* /*context*/,
     const NewResourceRequest* request, EmptyResponse* /*response*/)
 {
-  auto virtual_object = std::make_unique<VirtualObject>(request->id());
+  auto virtual_object = std::make_unique<VirtualObject>(
+      request->id(), pool_->update_rendering_queue());
 
   pool_->virtual_objects()->Add(std::move(virtual_object));
 
@@ -31,9 +32,12 @@ VirtualObjectServiceImpl::Delete(grpc::ServerContext* /*context*/,
 
 grpc::Status
 VirtualObjectServiceImpl::Commit(grpc::ServerContext* /*context*/,
-    const VirtualObjectCommitRequest* /*request*/, EmptyResponse* /*response*/)
+    const VirtualObjectCommitRequest* request, EmptyResponse* /*response*/)
 {
-  // TODO:
+  auto virtual_object = pool_->virtual_objects()->Get(request->id());
+
+  virtual_object->Commit();
+
   return grpc::Status::OK;
 }
 

--- a/src/client/service/virtual-object.cc
+++ b/src/client/service/virtual-object.cc
@@ -1,0 +1,40 @@
+#include "client/service/virtual-object.h"
+
+#include "client/resource-pool.h"
+
+namespace zen::remote::client::service {
+
+VirtualObjectServiceImpl::VirtualObjectServiceImpl(ResourcePool* pool)
+    : pool_(pool)
+{
+}
+
+grpc::Status
+VirtualObjectServiceImpl::New(grpc::ServerContext* /*context*/,
+    const NewResourceRequest* request, EmptyResponse* /*response*/)
+{
+  auto virtual_object = std::make_unique<VirtualObject>(request->id());
+
+  pool_->virtual_objects()->Add(std::move(virtual_object));
+
+  return grpc::Status::OK;
+}
+
+grpc::Status
+VirtualObjectServiceImpl::Delete(grpc::ServerContext* /*context*/,
+    const DeleteResourceRequest* request, EmptyResponse* /*response*/)
+{
+  pool_->virtual_objects()->ScheduleRemove(request->id());
+
+  return grpc::Status::OK;
+}
+
+grpc::Status
+VirtualObjectServiceImpl::Commit(grpc::ServerContext* /*context*/,
+    const VirtualObjectCommitRequest* /*request*/, EmptyResponse* /*response*/)
+{
+  // TODO:
+  return grpc::Status::OK;
+}
+
+}  // namespace zen::remote::client::service

--- a/src/client/service/virtual-object.h
+++ b/src/client/service/virtual-object.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "core/common.h"
+#include "virtual-object.grpc.pb.h"
+
+namespace zen::remote::client {
+class ResourcePool;
+}
+
+namespace zen::remote::client::service {
+
+class VirtualObjectServiceImpl final : public VirtualObjectService::Service {
+ public:
+  DISABLE_MOVE_AND_COPY(VirtualObjectServiceImpl);
+  VirtualObjectServiceImpl() = delete;
+  VirtualObjectServiceImpl(ResourcePool* pool);
+
+  virtual grpc::Status New(grpc::ServerContext* context,
+      const NewResourceRequest* request, EmptyResponse* response) override;
+
+  virtual grpc::Status Delete(grpc::ServerContext* context,
+      const DeleteResourceRequest* request, EmptyResponse* response) override;
+
+  virtual grpc::Status Commit(grpc::ServerContext* context,
+      const VirtualObjectCommitRequest* request,
+      EmptyResponse* response) override;
+
+ private:
+  ResourcePool* pool_;
+};
+
+}  // namespace zen::remote::client::service

--- a/src/client/virtual-object.cc
+++ b/src/client/virtual-object.cc
@@ -1,10 +1,15 @@
 #include "client/virtual-object.h"
 
+#include "client/atomic-command-queue.h"
 #include "client/rendering-unit.h"
 
 namespace zen::remote::client {
 
-VirtualObject::VirtualObject(uint64_t id) : id_(id) {}
+VirtualObject::VirtualObject(
+    uint64_t id, AtomicCommandQueue *update_rendering_queue)
+    : id_(id), update_rendering_queue_(update_rendering_queue)
+{
+}
 
 uint64_t
 VirtualObject::id()
@@ -13,16 +18,32 @@ VirtualObject::id()
 }
 
 void
-VirtualObject::ForEachRenderingUnit(
-    std::function<void(IRenderingUnit*)> /*func*/)
+VirtualObject::ForEachRenderingUnit(std::function<void(IRenderingUnit *)> func)
 {
-  // TODO:
+  ForEachWeakPtr<std::list, RenderingUnit>(rendering_.rendering_units_,
+      [func](std::shared_ptr<RenderingUnit> unit) { func(unit.get()); });
 }
 
 void
-VirtualObject::AddRenderingUnit(std::weak_ptr<RenderingUnit> /*rendering_unit*/)
+VirtualObject::Commit()
 {
-  // TODO:
+  ForEachWeakPtr<std::list, RenderingUnit>(pending_.rendering_units_,
+      [](std::shared_ptr<RenderingUnit> unit) { unit->Commit(); });
+
+  auto command = std::make_unique<Command>(
+      [rendering_units = pending_.rendering_units_, this]() {
+        rendering_.rendering_units_ = rendering_units;
+      });
+
+  update_rendering_queue_->Push(std::move(command));
+
+  update_rendering_queue_->Commit();
+}
+
+void
+VirtualObject::AddRenderingUnit(std::weak_ptr<RenderingUnit> rendering_unit)
+{
+  pending_.rendering_units_.push_back(rendering_unit);
 }
 
 }  // namespace zen::remote::client

--- a/src/client/virtual-object.cc
+++ b/src/client/virtual-object.cc
@@ -1,0 +1,28 @@
+#include "client/virtual-object.h"
+
+#include "client/rendering-unit.h"
+
+namespace zen::remote::client {
+
+VirtualObject::VirtualObject(uint64_t id) : id_(id) {}
+
+uint64_t
+VirtualObject::id()
+{
+  return id_;
+}
+
+void
+VirtualObject::ForEachRenderingUnit(
+    std::function<void(IRenderingUnit*)> /*func*/)
+{
+  // TODO:
+}
+
+void
+VirtualObject::AddRenderingUnit(std::weak_ptr<RenderingUnit> /*rendering_unit*/)
+{
+  // TODO:
+}
+
+}  // namespace zen::remote::client

--- a/src/client/virtual-object.h
+++ b/src/client/virtual-object.h
@@ -7,21 +7,37 @@
 namespace zen::remote::client {
 
 class RenderingUnit;
+class AtomicCommandQueue;
 
 class VirtualObject final : public IVirtualObject, public IResource {
  public:
   DISABLE_MOVE_AND_COPY(VirtualObject);
   VirtualObject() = delete;
-  VirtualObject(uint64_t id);
+  VirtualObject(uint64_t id, AtomicCommandQueue *update_rendering_queue);
+
+  /** Used in the update thread */
+  void Commit();
+
+  /** Used in the update thread */
+  void AddRenderingUnit(std::weak_ptr<RenderingUnit> rendering_unit);
+
+  /** Used in the rendering thread */
+  void ForEachRenderingUnit(
+      std::function<void(IRenderingUnit *)> func) override;
 
   uint64_t id() override;
 
-  void ForEachRenderingUnit(std::function<void(IRenderingUnit*)> func) override;
-
-  void AddRenderingUnit(std::weak_ptr<RenderingUnit> rendering_unit);
-
  private:
   const uint64_t id_;
+  AtomicCommandQueue *update_rendering_queue_;
+
+  struct {
+    std::list<std::weak_ptr<RenderingUnit>> rendering_units_;
+  } pending_;
+
+  struct {
+    std::list<std::weak_ptr<RenderingUnit>> rendering_units_;
+  } rendering_;
 };
 
 }  // namespace zen::remote::client

--- a/src/client/virtual-object.h
+++ b/src/client/virtual-object.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "client/resource.h"
+#include "core/common.h"
+#include "zen-remote/client/virtual-object.h"
+
+namespace zen::remote::client {
+
+class RenderingUnit;
+
+class VirtualObject final : public IVirtualObject, public IResource {
+ public:
+  DISABLE_MOVE_AND_COPY(VirtualObject);
+  VirtualObject() = delete;
+  VirtualObject(uint64_t id);
+
+  uint64_t id() override;
+
+  void ForEachRenderingUnit(std::function<void(IRenderingUnit*)> func) override;
+
+  void AddRenderingUnit(std::weak_ptr<RenderingUnit> rendering_unit);
+
+ private:
+  const uint64_t id_;
+};
+
+}  // namespace zen::remote::client

--- a/src/core/common.h
+++ b/src/core/common.h
@@ -2,6 +2,30 @@
 
 namespace zen::remote {
 
+/**
+ * Iterates the container of std::weak_ptr. If the weak_ptr is empty, it is
+ * removed from the container.
+ */
+template <template <class> typename C, typename T>
+void
+ForEachWeakPtr(C<std::weak_ptr<T>> &container,
+    std::function<void(std::shared_ptr<T>)> func)
+{
+  // Add other types of container if needed
+  static_assert(std::is_same<C<int>, std::list<int>>::value ||
+                    std::is_same<C<int>, std::vector<int>>::value,
+      "C must be one of [std::list, std::vector]");
+
+  for (auto it = container.begin(); it != container.end();) {
+    if (auto item = (*it).lock()) {
+      func(item);
+      ++it;
+    } else {
+      it = container.erase(it);
+    }
+  }
+}
+
 #define DISABLE_MOVE_AND_COPY(Class)        \
   Class(const Class &) = delete;            \
   Class(Class &&) = delete;                 \

--- a/src/core/connection/peer.cc
+++ b/src/core/connection/peer.cc
@@ -25,6 +25,18 @@ struct DiscoverPacket {
 namespace asio = boost::asio;
 namespace ip = boost::asio::ip;
 
+Peer::Peer(Target target, std::shared_ptr<Context> context)
+    : target_(target),
+      context_(std::move(context)),
+      udp_socket_(context_->io_context()),
+      tcp_socket_(context_->io_context()),
+      tcp_acceptor_(context_->io_context()),
+      udp_socket_source_(std::make_unique<FdSource>()),
+      tcp_socket_source_(std::make_unique<FdSource>()),
+      tcp_acceptor_source_(std::make_unique<FdSource>())
+{
+}
+
 bool
 Peer::StartDiscover()
 {

--- a/src/core/connection/peer.h
+++ b/src/core/connection/peer.h
@@ -17,15 +17,8 @@ class Peer {
   };
 
   DISABLE_MOVE_AND_COPY(Peer);
-  Peer(Target target, std::shared_ptr<Context> context)
-      : target_(target),
-        context_(std::move(context)),
-        udp_socket_(context_->io_context()),
-        tcp_socket_(context_->io_context()),
-        tcp_acceptor_(context_->io_context()),
-        udp_socket_source_(std::make_unique<FdSource>()),
-        tcp_socket_source_(std::make_unique<FdSource>()),
-        tcp_acceptor_source_(std::make_unique<FdSource>()){};
+  Peer() = delete;
+  Peer(Target target, std::shared_ptr<Context> context);
   ~Peer() = default;
 
   bool StartDiscover();

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -11,7 +11,6 @@ struct Logger {
 
   DISABLE_MOVE_AND_COPY(Logger);
   Logger() = default;
-  virtual ~Logger() = default;
 
   void Print(Severity severity, const char* pretty_function, const char* file,
       int line, const char* format, ...)

--- a/src/core/readers-writer-lock.cc
+++ b/src/core/readers-writer-lock.cc
@@ -2,7 +2,15 @@
 
 namespace zen::remote {
 
+ReadersWriterLock::ReadScope::ReadScope(ReadersWriterLock* lock) : lock_(lock)
+{
+}
+
 ReadersWriterLock::ReadScope::~ReadScope() { lock_->EndRead(); }
+
+ReadersWriterLock::WriteScope::WriteScope(ReadersWriterLock* lock) : lock_(lock)
+{
+}
 
 ReadersWriterLock::WriteScope::~WriteScope() { lock_->EndWrite(); }
 

--- a/src/core/readers-writer-lock.h
+++ b/src/core/readers-writer-lock.h
@@ -11,7 +11,8 @@ class ReadersWriterLock {
   class ReadScope {
    public:
     DISABLE_MOVE_AND_COPY(ReadScope);
-    ReadScope(ReadersWriterLock* lock) : lock_(lock){};
+    ReadScope() = delete;
+    ReadScope(ReadersWriterLock* lock);
 
     ~ReadScope();
 
@@ -22,7 +23,8 @@ class ReadersWriterLock {
   class WriteScope {
    public:
     DISABLE_MOVE_AND_COPY(WriteScope);
-    WriteScope(ReadersWriterLock* lock) : lock_(lock){};
+    WriteScope() = delete;
+    WriteScope(ReadersWriterLock* lock);
 
     ~WriteScope();
 
@@ -44,9 +46,9 @@ class ReadersWriterLock {
   void BeginWrite();
   void EndWrite();
 
-  uint32_t active_reader_count_;
-  uint32_t waiting_writer_count_;
-  bool writer_active_;
+  uint32_t active_reader_count_ = 0;
+  uint32_t waiting_writer_count_ = 0;
+  bool writer_active_ = false;
   std::condition_variable cond_;
   std::mutex mtx_;
 };

--- a/src/server/gl-buffer.cc
+++ b/src/server/gl-buffer.cc
@@ -18,10 +18,7 @@ GlBuffer::GlBuffer(std::shared_ptr<Remote> remote)
 void
 GlBuffer::Init()
 {
-  uint64_t id = id_;
-  auto remote = remote_;
-
-  auto job = std::make_unique<Job>([id, remote](bool cancel) {
+  auto job = std::make_unique<Job>([id = id_, remote = remote_](bool cancel) {
     if (cancel) return;
 
     auto channel = remote->peer()->grpc_channel();
@@ -45,10 +42,7 @@ GlBuffer::Init()
 
 GlBuffer::~GlBuffer()
 {
-  uint64_t id = id_;
-  auto remote = remote_;
-
-  auto job = std::make_unique<Job>([id, remote](bool cancel) {
+  auto job = std::make_unique<Job>([id = id_, remote = remote_](bool cancel) {
     if (cancel) return;
 
     auto channel = remote->peer()->grpc_channel();

--- a/src/server/gl-buffer.cc
+++ b/src/server/gl-buffer.cc
@@ -1,0 +1,102 @@
+#include "server/gl-buffer.h"
+
+#include "core/connection/peer.h"
+#include "core/logger.h"
+#include "gl-buffer.grpc.pb.h"
+#include "server/job-queue.h"
+#include "server/job.h"
+#include "server/remote.h"
+
+namespace zen::remote::server {
+
+GlBuffer::GlBuffer(std::shared_ptr<Remote> remote)
+    : remote_(std::move(remote)),
+      id_(remote_->NewSerial(Remote::SerialType::kResource))
+{
+}
+
+void
+GlBuffer::Init()
+{
+  uint64_t id = id_;
+  auto remote = remote_;
+
+  auto job = std::make_unique<Job>([id, remote](bool cancel) {
+    if (cancel) return;
+
+    auto &peer = remote->peer();
+
+    auto host_port = peer->endpoint().address().to_string() + ":" +
+                     std::to_string(kGrpcPort);
+
+    auto channel =
+        grpc::CreateChannel(host_port, grpc::InsecureChannelCredentials());
+
+    auto stub = GlBufferService::NewStub(channel);
+
+    NewResourceRequest request;
+    EmptyResponse response;
+    grpc::ClientContext context;
+
+    request.set_id(id);
+
+    auto status = stub->New(&context, request, &response);
+    if (!status.ok()) {
+      LOG_WARN("Failed to create a new GL buffer");
+    }
+  });
+
+  remote_->job_queue()->Push(std::move(job));
+}
+
+GlBuffer::~GlBuffer()
+{
+  uint64_t id = id_;
+  auto remote = remote_;
+
+  auto job = std::make_unique<Job>([id, remote](bool cancel) {
+    if (cancel) return;
+
+    auto &peer = remote->peer();
+
+    auto host_port = peer->endpoint().address().to_string() + ":" +
+                     std::to_string(kGrpcPort);
+
+    auto channel =
+        grpc::CreateChannel(host_port, grpc::InsecureChannelCredentials());
+
+    auto stub = GlBufferService::NewStub(channel);
+
+    DeleteResourceRequest request;
+    EmptyResponse response;
+    grpc::ClientContext context;
+
+    request.set_id(id);
+
+    auto status = stub->Delete(&context, request, &response);
+    if (!status.ok()) {
+      LOG_WARN("Failed to destroy a gl buffer");
+    }
+  });
+
+  remote_->job_queue()->Push(std::move(job));
+}
+
+uint64_t
+GlBuffer::id()
+{
+  return id_;
+}
+
+std::unique_ptr<IGlBuffer>
+CreateGlBuffer(std::shared_ptr<IRemote> remote)
+{
+  auto gl_buffer =
+      std::make_unique<GlBuffer>(std::dynamic_pointer_cast<Remote>(remote));
+
+  gl_buffer->Init();
+
+  return gl_buffer;
+}
+
+}  // namespace zen::remote::server

--- a/src/server/gl-buffer.h
+++ b/src/server/gl-buffer.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "core/common.h"
+#include "zen-remote/server/gl-buffer.h"
+
+namespace zen::remote::server {
+
+class Remote;
+
+class GlBuffer final : public IGlBuffer {
+ public:
+  DISABLE_MOVE_AND_COPY(GlBuffer);
+  GlBuffer() = delete;
+  GlBuffer(std::shared_ptr<Remote> remote);
+  ~GlBuffer();
+
+  void Init();
+
+  uint64_t id() override;
+
+ private:
+  std::shared_ptr<Remote> remote_;
+  uint64_t id_;
+};
+
+}  // namespace zen::remote::server

--- a/src/server/job.cc
+++ b/src/server/job.cc
@@ -2,6 +2,11 @@
 
 namespace zen::remote::server {
 
+Job::Job(std::function<void(bool cancel)> perform_func)
+    : perform_func_(perform_func)
+{
+}
+
 void
 Job::Perform(bool cancel)
 {

--- a/src/server/job.h
+++ b/src/server/job.h
@@ -15,10 +15,7 @@ class Job {
  public:
   DISABLE_MOVE_AND_COPY(Job);
   Job() = delete;
-  Job(std::function<void(bool cancel)> perform_func)
-      : perform_func_(perform_func)
-  {
-  }
+  Job(std::function<void(bool cancel)> perform_func);
 
  private:
   friend class JobQueue;

--- a/src/server/remote.cc
+++ b/src/server/remote.cc
@@ -2,6 +2,7 @@
 
 #include "core/connection/peer.h"
 #include "core/logger.h"
+#include "job-queue.h"
 #include "zen-remote/server/remote.h"
 
 namespace zen::remote::server {

--- a/src/server/remote.h
+++ b/src/server/remote.h
@@ -1,11 +1,21 @@
 #pragma once
 
-#include "core/connection/peer.h"
-#include "core/context.h"
-#include "job-queue.h"
+#include "core/common.h"
 #include "zen-remote/server/remote.h"
 
+namespace zen::remote {
+
+class Context;
+
+namespace connection {
+class Peer;
+}
+
+}  // namespace zen::remote
+
 namespace zen::remote::server {
+
+class JobQueue;
 
 class Remote : public IRemote {
  public:
@@ -14,6 +24,8 @@ class Remote : public IRemote {
     kCount,
   };
 
+  DISABLE_MOVE_AND_COPY(Remote);
+  Remote() = delete;
   Remote(std::unique_ptr<ILoop> loop);
 
   void Start() override;

--- a/src/server/rendering-unit.cc
+++ b/src/server/rendering-unit.cc
@@ -18,11 +18,8 @@ RenderingUnit::RenderingUnit(std::shared_ptr<Remote> remote)
 void
 RenderingUnit::Init(uint64_t virtual_object_id)
 {
-  uint64_t id = id_;
-  auto remote = remote_;
-
-  auto job =
-      std::make_unique<Job>([id, virtual_object_id, remote](bool cancel) {
+  auto job = std::make_unique<Job>(
+      [id = id_, virtual_object_id, remote = remote_](bool cancel) {
         if (cancel) return;
 
         auto channel = remote->peer()->grpc_channel();
@@ -48,28 +45,27 @@ RenderingUnit::Init(uint64_t virtual_object_id)
 void
 RenderingUnit::GlEnableVertexAttribArray(uint32_t index)
 {
-  uint64_t id = id_;
-  auto remote = remote_;
+  auto job =
+      std::make_unique<Job>([id = id_, index, remote = remote_](bool cancel) {
+        if (cancel) return;
 
-  auto job = std::make_unique<Job>([id, index, remote](bool cancel) {
-    if (cancel) return;
+        auto channel = remote->peer()->grpc_channel();
 
-    auto channel = remote->peer()->grpc_channel();
+        auto stub = RenderingUnitService::NewStub(channel);
 
-    auto stub = RenderingUnitService::NewStub(channel);
+        GlEnableVertexAttribArrayRequest request;
+        EmptyResponse response;
+        grpc::ClientContext context;
 
-    GlEnableVertexAttribArrayRequest request;
-    EmptyResponse response;
-    grpc::ClientContext context;
+        request.set_id(id);
+        request.set_index(index);
 
-    request.set_id(id);
-    request.set_index(index);
-
-    auto status = stub->GlEnableVertexAttribArray(&context, request, &response);
-    if (!status.ok()) {
-      LOG_WARN("GlEnableVertexAttribArray failed");
-    }
-  });
+        auto status =
+            stub->GlEnableVertexAttribArray(&context, request, &response);
+        if (!status.ok()) {
+          LOG_WARN("GlEnableVertexAttribArray failed");
+        }
+      });
 
   remote_->job_queue()->Push(std::move(job));
 }
@@ -77,29 +73,27 @@ RenderingUnit::GlEnableVertexAttribArray(uint32_t index)
 void
 RenderingUnit::GlDisableVertexAttribArray(uint32_t index)
 {
-  uint64_t id = id_;
-  auto remote = remote_;
+  auto job =
+      std::make_unique<Job>([id = id_, index, remote = remote_](bool cancel) {
+        if (cancel) return;
 
-  auto job = std::make_unique<Job>([id, index, remote](bool cancel) {
-    if (cancel) return;
+        auto channel = remote->peer()->grpc_channel();
 
-    auto channel = remote->peer()->grpc_channel();
+        auto stub = RenderingUnitService::NewStub(channel);
 
-    auto stub = RenderingUnitService::NewStub(channel);
+        GlDisableVertexAttribArrayRequest request;
+        EmptyResponse response;
+        grpc::ClientContext context;
 
-    GlDisableVertexAttribArrayRequest request;
-    EmptyResponse response;
-    grpc::ClientContext context;
+        request.set_id(id);
+        request.set_index(index);
 
-    request.set_id(id);
-    request.set_index(index);
-
-    auto status =
-        stub->GlDisableVertexAttribArray(&context, request, &response);
-    if (!status.ok()) {
-      LOG_WARN("GlDisableVertexAttribArray failed");
-    }
-  });
+        auto status =
+            stub->GlDisableVertexAttribArray(&context, request, &response);
+        if (!status.ok()) {
+          LOG_WARN("GlDisableVertexAttribArray failed");
+        }
+      });
 
   remote_->job_queue()->Push(std::move(job));
 }
@@ -109,12 +103,9 @@ RenderingUnit::GlVertexAttribPointer(uint32_t index, uint64_t buffer_id,
     int32_t size, uint64_t type, bool normalized, int32_t stride,
     uint64_t offset)
 {
-  uint64_t id = id_;
-  auto remote = remote_;
-
   auto job =
-      std::make_unique<Job>([id, index, buffer_id, size, type, normalized,
-                                stride, offset, remote](bool cancel) {
+      std::make_unique<Job>([id = id_, index, buffer_id, size, type, normalized,
+                                stride, offset, remote = remote_](bool cancel) {
         if (cancel) return;
 
         auto channel = remote->peer()->grpc_channel();
@@ -145,10 +136,7 @@ RenderingUnit::GlVertexAttribPointer(uint32_t index, uint64_t buffer_id,
 
 RenderingUnit::~RenderingUnit()
 {
-  uint64_t id = id_;
-  auto remote = remote_;
-
-  auto job = std::make_unique<Job>([id, remote](bool cancel) {
+  auto job = std::make_unique<Job>([id = id_, remote = remote_](bool cancel) {
     if (cancel) return;
 
     auto channel = remote->peer()->grpc_channel();

--- a/src/server/rendering-unit.cc
+++ b/src/server/rendering-unit.cc
@@ -1,9 +1,19 @@
 #include "server/rendering-unit.h"
 
+#include "core/connection/peer.h"
 #include "core/logger.h"
 #include "rendering-unit.grpc.pb.h"
+#include "server/job-queue.h"
+#include "server/job.h"
+#include "server/remote.h"
 
 namespace zen::remote::server {
+
+RenderingUnit::RenderingUnit(std::shared_ptr<Remote> remote)
+    : remote_(std::move(remote)),
+      id_(remote_->NewSerial(Remote::SerialType::kResource))
+{
+}
 
 void
 RenderingUnit::Init()

--- a/src/server/rendering-unit.h
+++ b/src/server/rendering-unit.h
@@ -15,6 +15,11 @@ class RenderingUnit final : public IRenderingUnit {
   ~RenderingUnit();
 
   void Init();
+  void Commit() override;
+  void GlEnableVertexAttribArray(uint32_t index) override;
+  void GlDisableVertexAttribArray(uint32_t index) override;
+  void GlVertexAttribPointer(uint32_t index, uint64_t buffer_id, int32_t size,
+      uint64_t type, bool normalized, int32_t stride, uint64_t offset) override;
 
  private:
   std::shared_ptr<Remote> remote_;

--- a/src/server/rendering-unit.h
+++ b/src/server/rendering-unit.h
@@ -14,8 +14,7 @@ class RenderingUnit final : public IRenderingUnit {
   RenderingUnit(std::shared_ptr<Remote> remote);
   ~RenderingUnit();
 
-  void Init();
-  void Commit() override;
+  void Init(uint64_t virtual_object_id);
   void GlEnableVertexAttribArray(uint32_t index) override;
   void GlDisableVertexAttribArray(uint32_t index) override;
   void GlVertexAttribPointer(uint32_t index, uint64_t buffer_id, int32_t size,

--- a/src/server/rendering-unit.h
+++ b/src/server/rendering-unit.h
@@ -1,20 +1,17 @@
 #pragma once
 
 #include "core/common.h"
-#include "server/remote.h"
 #include "zen-remote/server/rendering-unit.h"
 
 namespace zen::remote::server {
+
+class Remote;
 
 class RenderingUnit final : public IRenderingUnit {
  public:
   DISABLE_MOVE_AND_COPY(RenderingUnit);
   RenderingUnit() = delete;
-  RenderingUnit(std::shared_ptr<Remote> remote)
-      : remote_(std::move(remote)),
-        id_(remote_->NewSerial(Remote::SerialType::kResource))
-  {
-  }
+  RenderingUnit(std::shared_ptr<Remote> remote);
   ~RenderingUnit();
 
   void Init();

--- a/src/server/virtual-object.h
+++ b/src/server/virtual-object.h
@@ -16,6 +16,8 @@ class VirtualObject final : public IVirtualObject {
 
   void Init();
 
+  void Commit() override;
+
   uint64_t id() override;
 
  private:

--- a/src/server/virtual-object.h
+++ b/src/server/virtual-object.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "core/common.h"
+#include "zen-remote/server/virtual-object.h"
+
+namespace zen::remote::server {
+
+class Remote;
+
+class VirtualObject final : public IVirtualObject {
+ public:
+  DISABLE_MOVE_AND_COPY(VirtualObject);
+  VirtualObject() = delete;
+  VirtualObject(std::shared_ptr<Remote>);
+  ~VirtualObject();
+
+  void Init();
+
+  uint64_t id() override;
+
+ private:
+  std::shared_ptr<Remote> remote_;
+  uint64_t id_;
+};
+
+}  // namespace zen::remote::server

--- a/src/test-client.cc
+++ b/src/test-client.cc
@@ -112,7 +112,7 @@ main(int /*argc*/, char const * /*argv*/[])
       static int render_unit_count = 0;
       int count = 0;
       remote->pool()->ForEachRenderingUnit(
-          [&count](std::shared_ptr<IRenderingUnit> & /*unit*/) { count++; });
+          [&count](IRenderingUnit * /*unit*/) { count++; });
       if (render_unit_count != count) {
         fprintf(stderr, "Rendering Unit Count: %d\n", count);
         render_unit_count = count;

--- a/src/test-client.cc
+++ b/src/test-client.cc
@@ -113,7 +113,7 @@ main(int /*argc*/, char const * /*argv*/[])
 
       counter++;
       if (counter > 30) {  // once per once second
-        fprintf(stderr, "== current resources ==");
+        fprintf(stderr, "== current resources ==\n");
         remote->pool()->Traverse([](auto virtual_object) {
           fprintf(stderr, "Virtual Object:\n");
           virtual_object->ForEachRenderingUnit(

--- a/src/test-client.cc
+++ b/src/test-client.cc
@@ -109,13 +109,17 @@ main(int /*argc*/, char const * /*argv*/[])
 
     {  // test code
       static auto t = std::chrono::system_clock::now();
-      static int render_unit_count = 0;
-      int count = 0;
-      remote->pool()->ForEachRenderingUnit(
-          [&count](IRenderingUnit * /*unit*/) { count++; });
-      if (render_unit_count != count) {
-        fprintf(stderr, "Rendering Unit Count: %d\n", count);
-        render_unit_count = count;
+      static int counter = 0;
+
+      counter++;
+      if (counter > 30) {  // once per once second
+        fprintf(stderr, "== current resources ==");
+        remote->pool()->Traverse([](auto virtual_object) {
+          fprintf(stderr, "Virtual Object:\n");
+          virtual_object->ForEachRenderingUnit(
+              [](auto /*unit*/) { fprintf(stderr, "  RenderingUnit:\n"); });
+        });
+        counter = 0;
       }
 
       // throttle back on this loop(approx. 30fps)


### PR DESCRIPTION
## Context

## Summary

- [x] refactor
  - minimum self-contained header file
  - move constructor to .cc
  - stop using smart pointer for non owning objects
- [x] add `gl-buffer`: representing the object created with `glCreateBuffers`.
- [x] add `virtual-object`
- [x] enable to commit state and use the state from rendering thread.

## How to check behavior

1. Build and install zen-remote
2. Build https://github.com/zigen-project/zen/pull/193
3. Start zen-desktop
4. Start `test-client` of zen-remote
5. Switch to immersive display system
6. Plug and unplug your pointing device
You will see the following log in the `test-client`

```log
== current resources ==
[remote] D:Sent UPD broadcast packet for client discovery
[remote] I:Server Found: 192.168.0.5
== current resources ==
Virtual Object:
  RenderingUnit:
== current resources ==
Virtual Object:
  RenderingUnit:
== current resources ==
== current resources ==
== current resources ==
== current resources ==
== current resources ==
Virtual Object:
  RenderingUnit:
== current resources ==
Virtual Object:
  RenderingUnit:
```