### PR TITLE
Add `GlDrawArrays`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(
   LANGUAGES C CXX
   HOMEPAGE_URL https://github.com/zigen-project/zen-remote
   DESCRIPTION "Library for ZEN to communicate with devices over a network"
-  VERSION 0.1.0.9
+  VERSION 0.1.0.10
 )
 
 set(CMAKE_CXX_STANDARD 17)

--- a/include/zen-remote/server/gl-base-technique.h
+++ b/include/zen-remote/server/gl-base-technique.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <zen-remote/server/buffer.h>
+#include <zen-remote/server/remote.h>
+
+#include <memory>
+
+namespace zen::remote::server {
+
+struct IGlBaseTechnique {
+  virtual ~IGlBaseTechnique() = default;
+
+  virtual void GlDrawArrays(uint32_t mode, int32_t first, uint32_t count) = 0;
+
+  virtual uint64_t id() = 0;
+};
+
+std::unique_ptr<IGlBaseTechnique> CreateGlBaseTechnique(
+    std::shared_ptr<IRemote> remote, uint64_t rendering_unit_id);
+
+}  // namespace zen::remote::server

--- a/include/zen-remote/server/rendering-unit.h
+++ b/include/zen-remote/server/rendering-unit.h
@@ -13,6 +13,8 @@ struct IRenderingUnit {
   virtual void GlVertexAttribPointer(uint32_t index, uint64_t buffer_id,
       int32_t size, uint64_t type, bool normalized, int32_t stride,
       uint64_t offset) = 0;
+
+  virtual uint64_t id() = 0;
 };
 
 std::unique_ptr<IRenderingUnit> CreateRenderingUnit(

--- a/protos/CMakeLists.txt
+++ b/protos/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(zen_remote_grpc_proto STATIC)
 
 set(protos
   "common"
+  "gl-base-technique"
   "gl-buffer"
   "rendering-unit"
   "virtual-object"

--- a/protos/gl-base-technique.proto
+++ b/protos/gl-base-technique.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package zen.remote;
+
+import "common.proto";
+
+service GlBaseTechniqueService
+{
+  rpc New(NewGlBaseTechniqueRequest) returns (EmptyResponse);
+
+  rpc Delete(DeleteResourceRequest) returns (EmptyResponse);
+
+  rpc GlDrawArrays(GlDrawArraysRequest) returns (EmptyResponse);
+}
+
+message NewGlBaseTechniqueRequest
+{
+  uint64 id = 1;
+  uint64 rendering_unit_id = 2;
+}
+
+message GlDrawArraysRequest
+{
+  uint64 id = 1;
+  uint32 mode = 2;
+  int32 first = 3;
+  uint32 count = 4;
+}

--- a/src/client/gl-base-technique.cc
+++ b/src/client/gl-base-technique.cc
@@ -1,0 +1,41 @@
+#include "client/gl-base-technique.h"
+
+#include "client/atomic-command-queue.h"
+#include "core/logger.h"
+
+namespace zen::remote::client {
+
+GlBaseTechnique::GlBaseTechnique(
+    uint64_t id, AtomicCommandQueue* update_rendering_queue)
+    : id_(id), update_rendering_queue_(update_rendering_queue)
+{
+}
+
+GlBaseTechnique::~GlBaseTechnique() {}
+
+void
+GlBaseTechnique::Commit()
+{
+  auto command = CreateCommand([]() {});
+
+  update_rendering_queue_->Push(std::move(command));
+}
+
+void
+GlBaseTechnique::GlDrawArrays(uint32_t mode, int32_t first, uint32_t count)
+{
+  LOG_DEBUG("remote client: DrawArrays(%u, %d, %u)", mode, first, count);
+}
+
+void
+GlBaseTechnique::Render()
+{
+}
+
+uint64_t
+GlBaseTechnique::id()
+{
+  return id_;
+}
+
+}  // namespace zen::remote::client

--- a/src/client/gl-base-technique.cc
+++ b/src/client/gl-base-technique.cc
@@ -16,14 +16,14 @@ GlBaseTechnique::~GlBaseTechnique() {}
 void
 GlBaseTechnique::Commit()
 {
-  if (pending_.data_damaged == false) return;
+  if (pending_.damaged == false) return;
 
   auto command = CreateCommand(
       [this]() { rendering_.render_mode = pending_.render_mode; });
 
   update_rendering_queue_->Push(std::move(command));
 
-  pending_.data_damaged = false;
+  pending_.damaged = false;
 }
 
 void
@@ -33,7 +33,7 @@ GlBaseTechnique::GlDrawArrays(uint32_t mode, int32_t first, uint32_t count)
   pending_.render_mode.mode = mode;
   pending_.render_mode.count = count;
   pending_.render_mode.first = first;
-  pending_.data_damaged = true;
+  pending_.damaged = true;
 }
 
 void

--- a/src/client/gl-base-technique.cc
+++ b/src/client/gl-base-technique.cc
@@ -18,8 +18,9 @@ GlBaseTechnique::Commit()
 {
   if (pending_.damaged == false) return;
 
-  auto command = CreateCommand(
-      [this]() { rendering_.render_mode = pending_.render_mode; });
+  auto command = CreateCommand([render_mode = pending_.render_mode, this]() {
+    rendering_.render_mode = render_mode;
+  });
 
   update_rendering_queue_->Push(std::move(command));
 

--- a/src/client/gl-base-technique.h
+++ b/src/client/gl-base-technique.h
@@ -32,5 +32,21 @@ class GlBaseTechnique final : public IResource {
  private:
   const uint64_t id_;
   AtomicCommandQueue *update_rendering_queue_;
+
+  struct RenderMode {
+    RenderMethod render_method;
+    uint32_t mode;
+    int32_t count;
+    int32_t first;
+  };
+
+  struct {
+    bool data_damaged = true;
+    RenderMode render_mode;
+  } pending_;
+
+  struct {
+    RenderMode render_mode;
+  } rendering_;
 };
 }  // namespace zen::remote::client

--- a/src/client/gl-base-technique.h
+++ b/src/client/gl-base-technique.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "client/resource.h"
+#include "core/common.h"
+
+namespace zen::remote::client {
+
+class AtomicCommandQueue;
+
+enum class RenderMethod {
+  kArrays,
+};
+
+class GlBaseTechnique final : public IResource {
+ public:
+  DISABLE_MOVE_AND_COPY(GlBaseTechnique);
+  GlBaseTechnique() = delete;
+  GlBaseTechnique(uint64_t id, AtomicCommandQueue *update_rendering_queue);
+  ~GlBaseTechnique();
+
+  /** Used in the update thread */
+  void Commit();
+
+  /** Used in the update thread */
+  void GlDrawArrays(uint32_t mode, int32_t first, uint32_t count);
+
+  /** Used in the rendering thread */
+  void Render();
+
+  uint64_t id() override;
+
+ private:
+  const uint64_t id_;
+  AtomicCommandQueue *update_rendering_queue_;
+};
+}  // namespace zen::remote::client

--- a/src/client/gl-base-technique.h
+++ b/src/client/gl-base-technique.h
@@ -7,10 +7,6 @@ namespace zen::remote::client {
 
 class AtomicCommandQueue;
 
-enum class RenderMethod {
-  kArrays,
-};
-
 class GlBaseTechnique final : public IResource {
  public:
   DISABLE_MOVE_AND_COPY(GlBaseTechnique);
@@ -32,6 +28,10 @@ class GlBaseTechnique final : public IResource {
  private:
   const uint64_t id_;
   AtomicCommandQueue *update_rendering_queue_;
+
+  enum class RenderMethod {
+    kArrays,
+  };
 
   struct RenderMode {
     RenderMethod render_method;

--- a/src/client/gl-base-technique.h
+++ b/src/client/gl-base-technique.h
@@ -41,7 +41,7 @@ class GlBaseTechnique final : public IResource {
   };
 
   struct {
-    bool data_damaged = true;
+    bool damaged = true;
     RenderMode render_mode;
   } pending_;
 

--- a/src/client/grpc-server.cc
+++ b/src/client/grpc-server.cc
@@ -1,5 +1,6 @@
 #include "client/grpc-server.h"
 
+#include "client/service/gl-base-technique.h"
 #include "client/service/gl-buffer.h"
 #include "client/service/rendering-unit.h"
 #include "client/service/serial-async-caller.h"
@@ -29,6 +30,7 @@ GrpcServer::Start()
     services.emplace_back(new service::VirtualObjectServiceImpl(pool_));
     services.emplace_back(new service::RenderingUnitServiceImpl(pool_));
     services.emplace_back(new service::GlBufferServiceImpl(pool_));
+    services.emplace_back(new service::GlBaseTechniqueServiceImpl(pool_));
 
     for (auto &service : services) {
       service->Register(builder);

--- a/src/client/rendering-unit.cc
+++ b/src/client/rendering-unit.cc
@@ -62,6 +62,13 @@ RenderingUnit::Commit()
 }
 
 void
+RenderingUnit::SetGlBaseTechnique(
+    std::weak_ptr<GlBaseTechnique> gl_base_technique)
+{
+  gl_base_technique_ = gl_base_technique;
+}
+
+void
 RenderingUnit::GlEnableVertexAttribArray(uint32_t index)
 {
   auto result = pending_.vertex_attribs.find(index);
@@ -108,7 +115,12 @@ RenderingUnit::Render(Camera* camera)
   glUseProgram(rendering_.program_id);
   GLint mvp_location = glGetUniformLocation(rendering_.program_id, "mvp");
   glUniformMatrix4fv(mvp_location, 1, GL_FALSE, (float*)&camera->vp);
-  glDrawArrays(GL_LINES, 0, 2);
+
+  auto gl_base_technique = gl_base_technique_.lock();
+  if (gl_base_technique) {
+    gl_base_technique->Render();
+  }
+
   glBindVertexArray(0);
   glUseProgram(0);
 }

--- a/src/client/rendering-unit.cc
+++ b/src/client/rendering-unit.cc
@@ -29,8 +29,7 @@ RenderingUnit::Commit()
     }
   }
 
-  auto gl_base_technique = gl_base_technique_.lock();
-  if (gl_base_technique) {
+  if (auto gl_base_technique = gl_base_technique_.lock()) {
     gl_base_technique->Commit();
   }
 
@@ -121,8 +120,7 @@ RenderingUnit::Render(Camera* camera)
   GLint mvp_location = glGetUniformLocation(rendering_.program_id, "mvp");
   glUniformMatrix4fv(mvp_location, 1, GL_FALSE, (float*)&camera->vp);
 
-  auto gl_base_technique = gl_base_technique_.lock();
-  if (gl_base_technique) {
+  if (auto gl_base_technique = gl_base_technique_.lock()) {
     gl_base_technique->Render();
   }
 

--- a/src/client/rendering-unit.cc
+++ b/src/client/rendering-unit.cc
@@ -29,6 +29,11 @@ RenderingUnit::Commit()
     }
   }
 
+  auto gl_base_technique = gl_base_technique_.lock();
+  if (gl_base_technique) {
+    gl_base_technique->Commit();
+  }
+
   auto command = CreateCommand([attribs = pending_.vertex_attribs, this]() {
     if (rendering_.vao == 0) {
       glGenVertexArrays(1, &rendering_.vao);

--- a/src/client/rendering-unit.h
+++ b/src/client/rendering-unit.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "client/gl-base-technique.h"
 #include "client/resource.h"
 #include "core/common.h"
 
@@ -18,6 +19,9 @@ class RenderingUnit final : public IResource {
 
   /** Used in the update thread */
   void Commit();
+
+  /** Used in the update thread */
+  void SetGlBaseTechnique(std::weak_ptr<GlBaseTechnique> gl_base_technique);
 
   /** Used in the update thread */
   void GlEnableVertexAttribArray(uint32_t index);
@@ -52,6 +56,8 @@ class RenderingUnit final : public IResource {
 
   const uint64_t id_;
   AtomicCommandQueue *update_rendering_queue_;
+
+  std::weak_ptr<GlBaseTechnique> gl_base_technique_;
 
   struct {
     std::unordered_map<uint32_t, VertexAttrib> vertex_attribs;

--- a/src/client/resource-pool.h
+++ b/src/client/resource-pool.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "client/atomic-command-queue.h"
+#include "client/gl-base-technique.h"
 #include "client/gl-buffer.h"
 #include "client/rendering-unit.h"
 #include "client/resource-container.h"
@@ -17,6 +18,9 @@ using RenderingUnitContainer =
 
 using GlBufferContainer =
     ResourceContainer<GlBuffer, ResourceContainerType::kFindByIdIntensive>;
+
+using GlBaseTechniqueContainer = ResourceContainer<GlBaseTechnique,
+    ResourceContainerType::kFindByIdIntensive>;
 
 /**
  * @brief Retain all resources
@@ -45,6 +49,7 @@ class ResourcePool {
   inline VirtualObjectContainer *virtual_objects();
   inline RenderingUnitContainer *rendering_units();
   inline GlBufferContainer *gl_buffers();
+  inline GlBaseTechniqueContainer *gl_base_techniques();
 
   /** Commands to update rendering state of resources */
   inline AtomicCommandQueue *update_rendering_queue();
@@ -53,6 +58,7 @@ class ResourcePool {
   VirtualObjectContainer virtual_objects_;
   RenderingUnitContainer rendering_units_;
   GlBufferContainer gl_buffers_;
+  GlBaseTechniqueContainer gl_base_techniques_;
 
   AtomicCommandQueue update_rendering_queue_;
 };
@@ -73,6 +79,12 @@ inline GlBufferContainer *
 ResourcePool::gl_buffers()
 {
   return &gl_buffers_;
+}
+
+inline GlBaseTechniqueContainer *
+ResourcePool::gl_base_techniques()
+{
+  return &gl_base_techniques_;
 }
 
 inline AtomicCommandQueue *

--- a/src/client/service/gl-base-technique.cc
+++ b/src/client/service/gl-base-technique.cc
@@ -1,0 +1,73 @@
+#include "client/service/gl-base-technique.h"
+
+#include "client/resource-pool.h"
+#include "client/service/serial-async-caller.h"
+
+namespace zen::remote::client::service {
+
+GlBaseTechniqueServiceImpl::GlBaseTechniqueServiceImpl(ResourcePool* pool)
+    : pool_(pool)
+{
+}
+
+void
+GlBaseTechniqueServiceImpl::Register(grpc::ServerBuilder& builder)
+{
+  builder.RegisterService(&async_);
+}
+
+void
+GlBaseTechniqueServiceImpl::Listen(
+    grpc::ServerCompletionQueue* completion_queue,
+    SerialCommandQueue* command_queue)
+{
+  SerialAsyncCaller<&GlBaseTechniqueService::AsyncService::RequestNew,
+      &GlBaseTechniqueServiceImpl::New>::Listen(&async_, this, completion_queue,
+      command_queue);
+
+  SerialAsyncCaller<&GlBaseTechniqueService::AsyncService::RequestDelete,
+      &GlBaseTechniqueServiceImpl::Delete>::Listen(&async_, this,
+      completion_queue, command_queue);
+
+  SerialAsyncCaller<&GlBaseTechniqueService::AsyncService::RequestGlDrawArrays,
+      &GlBaseTechniqueServiceImpl::GlDrawArrays>::Listen(&async_, this,
+      completion_queue, command_queue);
+}
+
+grpc::Status
+GlBaseTechniqueServiceImpl::New(grpc::ServerContext* /*context*/,
+    const NewGlBaseTechniqueRequest* request, EmptyResponse* /*response*/)
+{
+  auto gl_base_technique = std::make_shared<GlBaseTechnique>(
+      request->id(), pool_->update_rendering_queue());
+  auto rendering_unit =
+      pool_->rendering_units()->Get(request->rendering_unit_id());
+
+  rendering_unit->SetGlBaseTechnique(gl_base_technique);
+
+  pool_->gl_base_techniques()->Add(std::move(gl_base_technique));
+
+  return grpc::Status::OK;
+}
+
+grpc::Status
+GlBaseTechniqueServiceImpl::Delete(grpc::ServerContext* /*context*/,
+    const DeleteResourceRequest* request, EmptyResponse* /*response*/)
+{
+  pool_->gl_base_techniques()->ScheduleRemove(request->id());
+  return grpc::Status::OK;
+}
+
+grpc::Status
+GlBaseTechniqueServiceImpl::GlDrawArrays(grpc::ServerContext* /*context*/,
+    const GlDrawArraysRequest* request, EmptyResponse* /*response*/)
+{
+  auto base_technique = pool_->gl_base_techniques()->Get(request->id());
+
+  base_technique->GlDrawArrays(
+      request->mode(), request->first(), request->count());
+
+  return grpc::Status::OK;
+}
+
+}  // namespace zen::remote::client::service

--- a/src/client/service/gl-base-technique.h
+++ b/src/client/service/gl-base-technique.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "client/service/serial-async-service.h"
+#include "core/common.h"
+#include "gl-base-technique.grpc.pb.h"
+
+namespace zen::remote::client {
+class ResourcePool;
+}
+
+namespace zen::remote::client::service {
+
+class GlBaseTechniqueServiceImpl final : public GlBaseTechniqueService::Service,
+                                         public ISerialAsyncService {
+ public:
+  DISABLE_MOVE_AND_COPY(GlBaseTechniqueServiceImpl);
+  GlBaseTechniqueServiceImpl() = delete;
+  GlBaseTechniqueServiceImpl(ResourcePool* pool);
+
+  void Register(grpc::ServerBuilder& builder) override;
+
+  void Listen(grpc::ServerCompletionQueue* completion_queue,
+      SerialCommandQueue* command_queue) override;
+
+  grpc::Status New(grpc::ServerContext* context,
+      const NewGlBaseTechniqueRequest* request,
+      EmptyResponse* response) override;
+
+  grpc::Status Delete(grpc::ServerContext* context,
+      const DeleteResourceRequest* request, EmptyResponse* response) override;
+
+  grpc::Status GlDrawArrays(grpc::ServerContext* context,
+      const GlDrawArraysRequest* request, EmptyResponse* response) override;
+
+ private:
+  GlBaseTechniqueService::AsyncService async_;
+  ResourcePool* pool_;
+};
+
+}  // namespace zen::remote::client::service

--- a/src/server/gl-base-technique.cc
+++ b/src/server/gl-base-technique.cc
@@ -20,33 +20,31 @@ GlBaseTechnique::GlBaseTechnique(std::shared_ptr<Remote> remote)
 void
 GlBaseTechnique::Init(uint64_t rendering_unit_id)
 {
-  auto job = CreateJob([id = id_, rendering_unit_id, remote = remote_](
-                           bool cancel) {
-    if (cancel) return;
+  auto job =
+      CreateJob([id = id_, rendering_unit_id, remote = remote_](bool cancel) {
+        if (cancel) return;
 
-    auto channel = remote->peer()->grpc_channel();
+        auto channel = remote->peer()->grpc_channel();
 
-    auto stub = GlBaseTechniqueService::NewStub(channel);
+        auto stub = GlBaseTechniqueService::NewStub(channel);
 
-    auto context = new SerialRequestContext(remote);
-    auto request = new NewGlBaseTechniqueRequest();
-    auto response = new EmptyResponse();
+        auto context = new SerialRequestContext(remote);
+        auto request = new NewGlBaseTechniqueRequest();
+        auto response = new EmptyResponse();
 
-    request->set_id(id);
-    request->set_rendering_unit_id(rendering_unit_id);
+        request->set_id(id);
+        request->set_rendering_unit_id(rendering_unit_id);
 
-    stub->async()->New(context, request, response,
-        [context, request, response](grpc::Status status) {
-          if (!status.ok() && status.error_code() != grpc::CANCELLED) {
-            LOG_WARN("Failed to call remote GlBaseTechnique::New [%d] %s | %s",
-                status.error_code(), status.error_message().c_str(),
-                status.error_details().c_str());
-          }
-          delete context;
-          delete request;
-          delete response;
-        });
-  });
+        stub->async()->New(context, request, response,
+            [context, request, response](grpc::Status status) {
+              if (!status.ok() && status.error_code() != grpc::CANCELLED) {
+                LOG_WARN("Failed to call remote GlBaseTechnique::New");
+              }
+              delete context;
+              delete request;
+              delete response;
+            });
+      });
 
   remote_->job_queue()->Push(std::move(job));
 }

--- a/src/server/gl-base-technique.cc
+++ b/src/server/gl-base-technique.cc
@@ -1,0 +1,135 @@
+#include "server/gl-base-technique.h"
+
+#include "core/connection/peer.h"
+#include "core/logger.h"
+#include "gl-base-technique.grpc.pb.h"
+#include "server/buffer.h"
+#include "server/job-queue.h"
+#include "server/job.h"
+#include "server/remote.h"
+#include "server/serial-request-context.h"
+
+namespace zen::remote::server {
+
+GlBaseTechnique::GlBaseTechnique(std::shared_ptr<Remote> remote)
+    : remote_(std::move(remote)),
+      id_(remote_->NewSerial(Remote::SerialType::kResource))
+{
+}
+
+void
+GlBaseTechnique::Init(uint64_t rendering_unit_id)
+{
+  auto job = CreateJob([id = id_, rendering_unit_id, remote = remote_](
+                           bool cancel) {
+    if (cancel) return;
+
+    auto channel = remote->peer()->grpc_channel();
+
+    auto stub = GlBaseTechniqueService::NewStub(channel);
+
+    auto context = new SerialRequestContext(remote);
+    auto request = new NewGlBaseTechniqueRequest();
+    auto response = new EmptyResponse();
+
+    request->set_id(id);
+    request->set_rendering_unit_id(rendering_unit_id);
+
+    stub->async()->New(context, request, response,
+        [context, request, response](grpc::Status status) {
+          if (!status.ok() && status.error_code() != grpc::CANCELLED) {
+            LOG_WARN("Failed to call remote GlBaseTechnique::New [%d] %s | %s",
+                status.error_code(), status.error_message().c_str(),
+                status.error_details().c_str());
+          }
+          delete context;
+          delete request;
+          delete response;
+        });
+  });
+
+  remote_->job_queue()->Push(std::move(job));
+}
+
+void
+GlBaseTechnique::GlDrawArrays(uint32_t mode, int32_t first, uint32_t count)
+{
+  auto job =
+      CreateJob([id = id_, remote = remote_, mode, first, count](bool cancel) {
+        if (cancel) return;
+
+        auto channel = remote->peer()->grpc_channel();
+
+        auto stub = GlBaseTechniqueService::NewStub(channel);
+
+        auto context = new SerialRequestContext(remote);
+        auto request = new GlDrawArraysRequest();
+        auto response = new EmptyResponse();
+
+        request->set_id(id);
+        request->set_mode(mode);
+        request->set_first(first);
+        request->set_count(count);
+
+        stub->async()->GlDrawArrays(context, request, response,
+            [context, request, response](grpc::Status status) {
+              if (!status.ok() && status.error_code() != grpc::CANCELLED) {
+                LOG_WARN("Failed to call remote GlBaseTechnique::GlDrawArrays");
+              }
+              delete context;
+              delete request;
+              delete response;
+            });
+      });
+
+  remote_->job_queue()->Push(std::move(job));
+}
+
+GlBaseTechnique::~GlBaseTechnique()
+{
+  auto job = CreateJob([id = id_, remote = remote_](bool cancel) {
+    if (cancel) return;
+
+    auto channel = remote->peer()->grpc_channel();
+
+    auto stub = GlBaseTechniqueService::NewStub(channel);
+
+    auto context = new SerialRequestContext(remote);
+    auto request = new DeleteResourceRequest();
+    auto response = new EmptyResponse();
+
+    request->set_id(id);
+
+    stub->async()->Delete(context, request, response,
+        [context, request, response](grpc::Status status) {
+          if (!status.ok() && status.error_code() != grpc::CANCELLED) {
+            LOG_WARN("Failed to call remote GlBaseTechnique::Delete");
+          }
+          delete context;
+          delete request;
+          delete response;
+        });
+  });
+
+  remote_->job_queue()->Push(std::move(job));
+}
+
+uint64_t
+GlBaseTechnique::id()
+{
+  return id_;
+}
+
+std::unique_ptr<IGlBaseTechnique>
+CreateGlBaseTechnique(
+    std::shared_ptr<IRemote> remote, uint64_t rendering_unit_id)
+{
+  auto gl_base_technique = std::make_unique<GlBaseTechnique>(
+      std::dynamic_pointer_cast<Remote>(remote));
+
+  gl_base_technique->Init(rendering_unit_id);
+
+  return gl_base_technique;
+}
+
+}  // namespace zen::remote::server

--- a/src/server/gl-base-technique.h
+++ b/src/server/gl-base-technique.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "core/common.h"
+#include "zen-remote/server/gl-base-technique.h"
+
+namespace zen::remote::server {
+
+class Remote;
+
+class GlBaseTechnique final : public IGlBaseTechnique {
+ public:
+  DISABLE_MOVE_AND_COPY(GlBaseTechnique);
+  GlBaseTechnique() = delete;
+  GlBaseTechnique(std::shared_ptr<Remote> remote);
+  ~GlBaseTechnique();
+
+  void Init(uint64_t rendering_unit_id);
+
+  void GlDrawArrays(uint32_t mode, int32_t first, uint32_t count) override;
+
+  uint64_t id() override;
+
+ private:
+  std::shared_ptr<Remote> remote_;
+  uint64_t id_;
+};
+
+}  // namespace zen::remote::server

--- a/src/server/rendering-unit.cc
+++ b/src/server/rendering-unit.cc
@@ -185,6 +185,12 @@ RenderingUnit::~RenderingUnit()
   remote_->job_queue()->Push(std::move(job));
 }
 
+uint64_t
+RenderingUnit::id()
+{
+  return id_;
+}
+
 std::unique_ptr<IRenderingUnit>
 CreateRenderingUnit(std::shared_ptr<IRemote> remote, uint64_t virtual_object_id)
 {

--- a/src/server/rendering-unit.h
+++ b/src/server/rendering-unit.h
@@ -19,6 +19,7 @@ class RenderingUnit final : public IRenderingUnit {
   void GlDisableVertexAttribArray(uint32_t index) override;
   void GlVertexAttribPointer(uint32_t index, uint64_t buffer_id, int32_t size,
       uint64_t type, bool normalized, int32_t stride, uint64_t offset) override;
+  uint64_t id() override;
 
  private:
   std::shared_ptr<Remote> remote_;


### PR DESCRIPTION
## Context

Currently, `RenderUnit` renders the vertex array using `glDrawArrays(GL_LINES, 0, 2)`. The client can't specify drawing method.

## Summary

Introducing `GlBaseTechnique` and using it with `GlDrawArrays` makes it possible to specify the number of vertices, etc.

## How to check behavior

1. apply some PR to other repository; zen, zen-oculus-display-system
2. start zen, switch display system to `immersive`
3. move your pointing device connected to zen

The behavior is expected to be the same as #21.
