### PR TITLE
fix session thread safety

### DIFF
--- a/src/server/job-queue.cc
+++ b/src/server/job-queue.cc
@@ -4,7 +4,10 @@ namespace zen::remote::server {
 
 JobQueue::~JobQueue()
 {
-  running_ = false;
+  {
+    std::lock_guard<std::mutex> lock(queue_mtx_);
+    running_ = false;
+  }
 
   if (!thread_.joinable()) return;
 

--- a/src/server/rendering-unit.cc
+++ b/src/server/rendering-unit.cc
@@ -17,15 +17,18 @@ RenderingUnit::RenderingUnit(std::shared_ptr<Session> session)
 void
 RenderingUnit::Init(uint64_t virtual_object_id)
 {
-  auto job =
-      CreateJob([id = id_, virtual_object_id, session = session_](bool cancel) {
-        if (cancel) return;
+  auto context = new SerialRequestContext(session_.get());
 
-        auto channel = session->grpc_channel();
+  auto job =
+      CreateJob([id = id_, virtual_object_id,
+                    channel = session_->grpc_channel(), context](bool cancel) {
+        if (cancel) {
+          delete context;
+          return;
+        }
 
         auto stub = RenderingUnitService::NewStub(channel);
 
-        auto context = new SerialRequestContext(session.get());
         auto request = new NewRenderingUnitRequest();
         auto response = new EmptyResponse();
 
@@ -49,14 +52,17 @@ RenderingUnit::Init(uint64_t virtual_object_id)
 void
 RenderingUnit::GlEnableVertexAttribArray(uint32_t index)
 {
-  auto job = CreateJob([id = id_, index, session = session_](bool cancel) {
-    if (cancel) return;
+  auto context = new SerialRequestContext(session_.get());
 
-    auto channel = session->grpc_channel();
+  auto job = CreateJob([id = id_, index, channel = session_->grpc_channel(),
+                           context](bool cancel) {
+    if (cancel) {
+      delete context;
+      return;
+    }
 
     auto stub = RenderingUnitService::NewStub(channel);
 
-    auto context = new SerialRequestContext(session.get());
     auto request = new GlEnableVertexAttribArrayRequest();
     auto response = new EmptyResponse();
 
@@ -82,14 +88,17 @@ RenderingUnit::GlEnableVertexAttribArray(uint32_t index)
 void
 RenderingUnit::GlDisableVertexAttribArray(uint32_t index)
 {
-  auto job = CreateJob([id = id_, index, session = session_](bool cancel) {
-    if (cancel) return;
+  auto context = new SerialRequestContext(session_.get());
 
-    auto channel = session->grpc_channel();
+  auto job = CreateJob([id = id_, index, channel = session_->grpc_channel(),
+                           context](bool cancel) {
+    if (cancel) {
+      delete context;
+      return;
+    }
 
     auto stub = RenderingUnitService::NewStub(channel);
 
-    auto context = new SerialRequestContext(session.get());
     auto request = new GlDisableVertexAttribArrayRequest();
     auto response = new EmptyResponse();
 
@@ -117,68 +126,74 @@ RenderingUnit::GlVertexAttribPointer(uint32_t index, uint64_t buffer_id,
     int32_t size, uint64_t type, bool normalized, int32_t stride,
     uint64_t offset)
 {
-  auto job = CreateJob([id = id_, index, buffer_id, size, type, normalized,
-                           stride, offset, session = session_](bool cancel) {
-    if (cancel) return;
+  auto context = new SerialRequestContext(session_.get());
 
-    auto channel = session->grpc_channel();
-
-    auto stub = RenderingUnitService::NewStub(channel);
-
-    auto context = new SerialRequestContext(session.get());
-    auto request = new GlVertexAttribPointerRequest();
-    auto response = new EmptyResponse();
-
-    request->set_id(id);
-    request->set_index(index);
-    request->set_buffer_id(buffer_id);
-    request->set_size(size);
-    request->set_type(type);
-    request->set_normalized(normalized);
-    request->set_stride(stride);
-    request->set_offset(offset);
-
-    stub->async()->GlVertexAttribPointer(context, request, response,
-        [context, request, response](grpc::Status status) {
-          if (!status.ok() && status.error_code() != grpc::CANCELLED) {
-            LOG_WARN(
-                "Failed to call remote "
-                "RenderingUnit::GlDisableVertexAttribArray");
-          }
+  auto job = CreateJob(
+      [id = id_, index, buffer_id, size, type, normalized, stride, offset,
+          channel = session_->grpc_channel(), context](bool cancel) {
+        if (cancel) {
           delete context;
-          delete request;
-          delete response;
-        });
-  });
+          return;
+        }
+
+        auto stub = RenderingUnitService::NewStub(channel);
+
+        auto request = new GlVertexAttribPointerRequest();
+        auto response = new EmptyResponse();
+
+        request->set_id(id);
+        request->set_index(index);
+        request->set_buffer_id(buffer_id);
+        request->set_size(size);
+        request->set_type(type);
+        request->set_normalized(normalized);
+        request->set_stride(stride);
+        request->set_offset(offset);
+
+        stub->async()->GlVertexAttribPointer(context, request, response,
+            [context, request, response](grpc::Status status) {
+              if (!status.ok() && status.error_code() != grpc::CANCELLED) {
+                LOG_WARN(
+                    "Failed to call remote "
+                    "RenderingUnit::GlDisableVertexAttribArray");
+              }
+              delete context;
+              delete request;
+              delete response;
+            });
+      });
 
   session_->job_queue()->Push(std::move(job));
 }
 
 RenderingUnit::~RenderingUnit()
 {
-  auto job = CreateJob([id = id_, session = session_](bool cancel) {
-    if (cancel) return;
+  auto context = new SerialRequestContext(session_.get());
 
-    auto channel = session->grpc_channel();
-
-    auto stub = RenderingUnitService::NewStub(channel);
-
-    auto context = new SerialRequestContext(session.get());
-    auto request = new DeleteResourceRequest();
-    auto response = new EmptyResponse();
-
-    request->set_id(id);
-
-    stub->async()->Delete(context, request, response,
-        [context, request, response](grpc::Status status) {
-          if (!status.ok() && status.error_code() != grpc::CANCELLED) {
-            LOG_WARN("Failed to call remote RenderingUnit::Delete");
-          }
+  auto job = CreateJob(
+      [id = id_, channel = session_->grpc_channel(), context](bool cancel) {
+        if (cancel) {
           delete context;
-          delete request;
-          delete response;
-        });
-  });
+          return;
+        }
+
+        auto stub = RenderingUnitService::NewStub(channel);
+
+        auto request = new DeleteResourceRequest();
+        auto response = new EmptyResponse();
+
+        request->set_id(id);
+
+        stub->async()->Delete(context, request, response,
+            [context, request, response](grpc::Status status) {
+              if (!status.ok() && status.error_code() != grpc::CANCELLED) {
+                LOG_WARN("Failed to call remote RenderingUnit::Delete");
+              }
+              delete context;
+              delete request;
+              delete response;
+            });
+      });
 
   session_->job_queue()->Push(std::move(job));
 }

--- a/src/server/session.cc
+++ b/src/server/session.cc
@@ -21,7 +21,10 @@ Session::Connect(std::shared_ptr<IPeer> peer)
 
   auto status = stub->New(&context, request, &response);
 
-  if (!status.ok()) return false;
+  if (!status.ok()) {
+    LOG_DEBUG("Failed to start session: %s", status.error_message().c_str());
+    return false;
+  }
 
   id_ = response.id();
 

--- a/src/server/virtual-object.cc
+++ b/src/server/virtual-object.cc
@@ -17,29 +17,32 @@ VirtualObject::VirtualObject(std::shared_ptr<Session> session)
 void
 VirtualObject::Init()
 {
-  auto job = CreateJob([id = id_, session = session_](bool cancel) {
-    if (cancel) return;
+  auto context = new SerialRequestContext(session_.get());
 
-    auto channel = session->grpc_channel();
-
-    auto stub = VirtualObjectService::NewStub(channel);
-
-    auto context = new SerialRequestContext(session.get());
-    auto request = new NewResourceRequest();
-    auto response = new EmptyResponse();
-
-    request->set_id(id);
-
-    stub->async()->New(context, request, response,
-        [context, request, response](grpc::Status status) {
-          if (!status.ok() && status.error_code() != grpc::CANCELLED) {
-            LOG_WARN("Failed to call remote VirtualObject::New");
-          }
+  auto job = CreateJob(
+      [id = id_, channel = session_->grpc_channel(), context](bool cancel) {
+        if (cancel) {
           delete context;
-          delete request;
-          delete response;
-        });
-  });
+          return;
+        }
+
+        auto stub = VirtualObjectService::NewStub(channel);
+
+        auto request = new NewResourceRequest();
+        auto response = new EmptyResponse();
+
+        request->set_id(id);
+
+        stub->async()->New(context, request, response,
+            [context, request, response](grpc::Status status) {
+              if (!status.ok() && status.error_code() != grpc::CANCELLED) {
+                LOG_WARN("Failed to call remote VirtualObject::New");
+              }
+              delete context;
+              delete request;
+              delete response;
+            });
+      });
 
   session_->job_queue()->Push(std::move(job));
 }
@@ -47,58 +50,64 @@ VirtualObject::Init()
 void
 VirtualObject::Commit()
 {
-  auto job = CreateJob([id = id_, session = session_](bool cancel) {
-    if (cancel) return;
+  auto context = new SerialRequestContext(session_.get());
 
-    auto channel = session->grpc_channel();
-
-    auto stub = VirtualObjectService::NewStub(channel);
-
-    auto context = new SerialRequestContext(session.get());
-    auto request = new VirtualObjectCommitRequest();
-    auto response = new EmptyResponse();
-
-    request->set_id(id);
-
-    stub->async()->Commit(context, request, response,
-        [context, request, response](grpc::Status status) {
-          if (!status.ok() && status.error_code() != grpc::CANCELLED) {
-            LOG_WARN("Failed to call remote VirtualObject::Commit");
-          }
+  auto job = CreateJob(
+      [id = id_, channel = session_->grpc_channel(), context](bool cancel) {
+        if (cancel) {
           delete context;
-          delete request;
-          delete response;
-        });
-  });
+          return;
+        }
+
+        auto stub = VirtualObjectService::NewStub(channel);
+
+        auto request = new VirtualObjectCommitRequest();
+        auto response = new EmptyResponse();
+
+        request->set_id(id);
+
+        stub->async()->Commit(context, request, response,
+            [context, request, response](grpc::Status status) {
+              if (!status.ok() && status.error_code() != grpc::CANCELLED) {
+                LOG_WARN("Failed to call remote VirtualObject::Commit");
+              }
+              delete context;
+              delete request;
+              delete response;
+            });
+      });
 
   session_->job_queue()->Push(std::move(job));
 }
 
 VirtualObject::~VirtualObject()
 {
-  auto job = CreateJob([id = id_, session = session_](bool cancel) {
-    if (cancel) return;
+  auto context = new SerialRequestContext(session_.get());
 
-    auto channel = session->grpc_channel();
-
-    auto stub = VirtualObjectService::NewStub(channel);
-
-    auto context = new SerialRequestContext(session.get());
-    auto request = new DeleteResourceRequest();
-    auto response = new EmptyResponse();
-
-    request->set_id(id);
-
-    stub->async()->Delete(context, request, response,
-        [context, request, response](grpc::Status status) {
-          if (!status.ok() && status.error_code() != grpc::CANCELLED) {
-            LOG_WARN("Failed to call remote VirtualObject::Delete");
-          }
+  auto job = CreateJob(
+      [id = id_, channel = session_->grpc_channel(), context](bool cancel) {
+        if (cancel) {
           delete context;
-          delete request;
-          delete response;
-        });
-  });
+          return;
+        }
+
+        auto stub = VirtualObjectService::NewStub(channel);
+
+        auto request = new DeleteResourceRequest();
+        auto response = new EmptyResponse();
+
+        request->set_id(id);
+
+        stub->async()->Delete(context, request, response,
+            [context, request, response](grpc::Status status) {
+              if (!status.ok() && status.error_code() != grpc::CANCELLED) {
+                LOG_WARN("Failed to call remote VirtualObject::Delete");
+              }
+              delete context;
+              delete request;
+              delete response;
+            });
+      });
 
   session_->job_queue()->Push(std::move(job));
 }


### PR DESCRIPTION
## Context

With previous implementation, Job has a shared_ptr of session, which causes circular reference.

Session -> Job Queue -> Job -> Session

## Summary

- [x] Stop having a shared_ptr of session in jobs.
