### PR TITLE
handle gRPC disconnection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(
   LANGUAGES C CXX
   HOMEPAGE_URL https://github.com/zigen-project/zen-remote
   DESCRIPTION "Library for ZEN to communicate with devices over a network"
-  VERSION 0.1.0.9
+  VERSION 0.1.0.10
 )
 
 set(CMAKE_CXX_STANDARD 17)

--- a/src/server/async-grpc-caller.h
+++ b/src/server/async-grpc-caller.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <type_traits>
+
+#include "core/common.h"
+#include "server/session-connection.h"
+
+namespace zen::remote::server {
+
+struct AsyncGrpcCallerBase {
+  virtual ~AsyncGrpcCallerBase() = default;
+  virtual void Start(grpc::CompletionQueue *cq) = 0;
+  virtual void Finish() = 0;
+};
+
+template <auto PrepareAsync>
+class AsyncGrpcCaller final : public AsyncGrpcCallerBase {
+  template <typename T>
+  struct template_parameter {
+    using type = T;
+  };
+
+  template <template <typename> typename T, typename P>
+  struct template_parameter<T<P>> {
+    using type = P;
+  };
+
+  using RequestRef = typename arg_type<1, decltype(PrepareAsync)>::type;
+  using RequestConst = typename std::remove_reference<RequestRef>::type;
+  using Request = typename std::remove_const<RequestConst>::type;
+
+  using Stub = typename class_type<decltype(PrepareAsync)>::type;
+
+  using ResponseReader = typename std::invoke_result<decltype(PrepareAsync),
+      Stub, typename arg_type<0, decltype(PrepareAsync)>::type,
+      typename arg_type<1, decltype(PrepareAsync)>::type,
+      typename arg_type<2, decltype(PrepareAsync)>::type>::type;
+
+  using Response =
+      typename template_parameter<typename ResponseReader::element_type>::type;
+
+  using Callback = std::function<void(Response *, grpc::Status *status)>;
+
+ public:
+  DISABLE_MOVE_AND_COPY(AsyncGrpcCaller);
+  AsyncGrpcCaller(std::unique_ptr<Stub> stub,
+      std::unique_ptr<grpc::ClientContext> context, Callback &&callback)
+      : context_(std::move(context)),
+        stub_(std::move(stub)),
+        callback_(std::forward<Callback>(callback))
+  {
+  }
+
+  void Start(grpc::CompletionQueue *cq) override
+  {
+    response_reader_ =
+        std::invoke(PrepareAsync, stub_.get(), context_.get(), request_, cq);
+
+    response_reader_->StartCall();
+
+    response_reader_->Finish(&response_, &status_, this);
+  };
+
+  void Finish() override { callback_(&response_, &status_); };
+
+  inline Request *request() { return &request_; }
+
+ private:
+  Request request_;
+  Response response_;
+  grpc::Status status_;
+  std::unique_ptr<grpc::ClientContext> context_;
+  ResponseReader response_reader_;
+  std::unique_ptr<Stub> stub_;
+  Callback callback_;
+};
+
+}  // namespace zen::remote::server

--- a/src/server/async-grpc-queue.cc
+++ b/src/server/async-grpc-queue.cc
@@ -1,0 +1,46 @@
+#include "async-grpc-queue.h"
+
+#include "async-grpc-caller.h"
+
+namespace zen::remote::server {
+
+AsyncGrpcQueue::~AsyncGrpcQueue() { Terminate(); }
+
+void
+AsyncGrpcQueue::Push(std::unique_ptr<AsyncGrpcCallerBase> caller)
+{
+  auto caller_raw = caller.release();
+
+  caller_raw->Start(&cq_);
+}
+
+void
+AsyncGrpcQueue::Start()
+{
+  if (thread_.joinable()) return;
+
+  thread_ = std::thread([this] {
+    void *tag;
+    bool ok = false;
+
+    while (cq_.Next(&tag, &ok)) {
+      auto caller = static_cast<AsyncGrpcCallerBase *>(tag);
+
+      caller->Finish();
+
+      delete caller;
+    }
+  });
+}
+
+void
+AsyncGrpcQueue::Terminate()
+{
+  if (!thread_.joinable()) return;
+
+  cq_.Shutdown();
+
+  thread_.join();
+}
+
+}  // namespace zen::remote::server

--- a/src/server/async-grpc-queue.h
+++ b/src/server/async-grpc-queue.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "core/common.h"
+
+namespace zen::remote::server {
+
+struct AsyncGrpcCallerBase;
+
+class AsyncGrpcQueue {
+ public:
+  DISABLE_MOVE_AND_COPY(AsyncGrpcQueue);
+  AsyncGrpcQueue() = default;
+  ~AsyncGrpcQueue();
+
+  void Push(std::unique_ptr<AsyncGrpcCallerBase> caller);
+
+  void Start();
+
+  void Terminate();
+
+ private:
+  std::thread thread_;
+  grpc::CompletionQueue cq_;
+};
+
+}  // namespace zen::remote::server

--- a/src/server/buffer.cc
+++ b/src/server/buffer.cc
@@ -30,8 +30,7 @@ Buffer::Init()
   auto delete_event_source = new FdSource();
 
   delete_event_source->fd = pipe_[0];
-  delete_event_source->mask =
-      FdSource::kReadable | FdSource::kHangup | FdSource::kError;
+  delete_event_source->mask = FdSource::kReadable;
   delete_event_source->callback = [delete_event_source,
                                       on_release = on_release_, loop = loop_,
                                       pipe_out = pipe_[0], pipe_in = pipe_[1]](

--- a/src/server/job-queue.h
+++ b/src/server/job-queue.h
@@ -21,6 +21,8 @@ class JobQueue {
 
   void StartWorkerThread();
 
+  void Terminate();
+
  private:
   std::queue<std::unique_ptr<IJob>> queue_;
   std::mutex queue_mtx_;

--- a/src/server/session-connection.cc
+++ b/src/server/session-connection.cc
@@ -1,0 +1,34 @@
+#include "server/session-connection.h"
+
+#include "core/logger.h"
+
+namespace zen::remote::server {
+
+SessionConnection::SessionConnection(int control_fd, std::string host_port)
+    : control_fd_(control_fd)
+{
+  grpc_channel_ =
+      grpc::CreateChannel(host_port, grpc::InsecureChannelCredentials());
+}
+
+void
+SessionConnection::Disable()
+{
+  std::lock_guard<std::mutex> lock(mtx_);
+  disabled_ = true;
+  control_fd_ = -1;
+}
+
+void
+SessionConnection::NotifyDisconnection()
+{
+  std::lock_guard<std::mutex> lock(mtx_);
+  if (disabled_) return;
+  uint8_t msg = kDisconnect;
+
+  if (control_fd_ > 0) {
+    write(control_fd_, &msg, sizeof(msg));
+  }
+}
+
+}  // namespace zen::remote::server

--- a/src/server/session-connection.h
+++ b/src/server/session-connection.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "core/common.h"
+
+namespace zen::remote::server {
+
+class SessionConnection {
+ public:
+  enum ConnectionControl : uint8_t {
+    kDisconnect = 0,
+  };
+
+  DISABLE_MOVE_AND_COPY(SessionConnection);
+  SessionConnection() = delete;
+  SessionConnection(int control_fd, std::string host_port);
+
+  /** Session calls this when session is about to be destroyed */
+  void Disable();
+
+  /** Program calls this to inform session to notify the gRPC connection lost */
+  void NotifyDisconnection();
+
+  inline std::shared_ptr<grpc::Channel> grpc_channel();
+
+ private:
+  std::shared_ptr<grpc::Channel> grpc_channel_;
+  bool disabled_ = false;
+  int control_fd_;
+  std::mutex mtx_;
+};
+
+inline std::shared_ptr<grpc::Channel>
+SessionConnection::grpc_channel()
+{
+  return grpc_channel_;
+}
+
+}  // namespace zen::remote::server

--- a/src/server/session.cc
+++ b/src/server/session.cc
@@ -1,19 +1,52 @@
 #include "server/session.h"
 
 #include "core/logger.h"
+#include "server/async-grpc-queue.h"
 #include "server/serial-request-context.h"
+#include "server/session-connection.h"
 #include "session.grpc.pb.h"
 
 namespace zen::remote::server {
 
+Session::Session(std::unique_ptr<ILoop> loop) : loop_(std::move(loop))
+{
+  pipe_[0] = 0;
+  pipe_[1] = 0;
+}
+
+Session::~Session()
+{
+  /**
+   * Terminate job queue first so that no additional work is enqueued to
+   * grpc_queue after termination.
+   */
+  job_queue_.Terminate();
+  grpc_queue_->Terminate();
+
+  if (connection_) connection_->Disable();
+
+  if (pipe_[0] != 0) {
+    close(pipe_[0]);
+    close(pipe_[1]);
+  }
+
+  if (control_event_source_) {
+    loop_->RemoveFd(control_event_source_);
+  }
+}
+
 bool
 Session::Connect(std::shared_ptr<IPeer> peer)
 {
-  auto host_port = peer->host() + ":" + std::to_string(kGrpcPort);
-  grpc_channel_ =
-      grpc::CreateChannel(host_port, grpc::InsecureChannelCredentials());
+  if (pipe2(pipe_, O_CLOEXEC | O_NONBLOCK) == -1) return false;
 
-  auto stub = SessionService::NewStub(grpc_channel_);
+  auto host_port = peer->host() + ":" + std::to_string(kGrpcPort);
+  connection_ = std::make_shared<SessionConnection>(pipe_[1], host_port);
+
+  grpc_queue_ = std::make_shared<AsyncGrpcQueue>();
+  grpc_queue_->Start();
+
+  auto stub = SessionService::NewStub(connection_->grpc_channel());
 
   grpc::ClientContext context;
   NewSessionRequest request;
@@ -23,10 +56,28 @@ Session::Connect(std::shared_ptr<IPeer> peer)
 
   if (!status.ok()) {
     LOG_DEBUG("Failed to start session: %s", status.error_message().c_str());
+    close(pipe_[0]);
+    close(pipe_[1]);
+    grpc_queue_.reset();
+    connection_.reset();
     return false;
   }
 
+  control_event_source_ = new FdSource();
+
+  control_event_source_->fd = pipe_[0];
+  control_event_source_->mask = FdSource::kReadable;
+  control_event_source_->callback = [this](int /*fd*/, uint32_t /*mask*/) {
+    if (connected_ == false) return;
+    connected_ = false;
+    this->connection_->Disable();
+    this->on_disconnect();  // this may destroy self
+  };
+
+  loop_->AddFd(control_event_source_);
+
   id_ = response.id();
+  connected_ = true;
 
   job_queue_.StartWorkerThread();
 
@@ -40,9 +91,9 @@ Session::NewSerial(Session::SerialType type)
 }
 
 std::unique_ptr<ISession>
-CreateSession(std::unique_ptr<ILoop> /*loop*/)
+CreateSession(std::unique_ptr<ILoop> loop)
 {
-  return std::make_unique<Session>();
+  return std::make_unique<Session>(std::move(loop));
 }
 
 }  // namespace zen::remote::server

--- a/src/server/virtual-object.cc
+++ b/src/server/virtual-object.cc
@@ -1,6 +1,8 @@
 #include "server/virtual-object.h"
 
 #include "core/logger.h"
+#include "server/async-grpc-caller.h"
+#include "server/async-grpc-queue.h"
 #include "server/job-queue.h"
 #include "server/job.h"
 #include "server/serial-request-context.h"
@@ -17,32 +19,32 @@ VirtualObject::VirtualObject(std::shared_ptr<Session> session)
 void
 VirtualObject::Init()
 {
-  auto context = new SerialRequestContext(session_.get());
+  auto context_raw = new SerialRequestContext(session_.get());
 
-  auto job = CreateJob(
-      [id = id_, channel = session_->grpc_channel(), context](bool cancel) {
-        if (cancel) {
-          delete context;
-          return;
-        }
+  auto job = CreateJob([id = id_, connection = session_->connection(),
+                           context_raw,
+                           grpc_queue = session_->grpc_queue()](bool cancel) {
+    auto context = std::unique_ptr<grpc::ClientContext>(context_raw);
+    if (cancel) {
+      return;
+    }
 
-        auto stub = VirtualObjectService::NewStub(channel);
+    auto stub = VirtualObjectService::NewStub(connection->grpc_channel());
 
-        auto request = new NewResourceRequest();
-        auto response = new EmptyResponse();
-
-        request->set_id(id);
-
-        stub->async()->New(context, request, response,
-            [context, request, response](grpc::Status status) {
-              if (!status.ok() && status.error_code() != grpc::CANCELLED) {
+    auto caller =
+        new AsyncGrpcCaller<&VirtualObjectService::Stub::PrepareAsyncNew>(
+            std::move(stub), std::move(context),
+            [connection](EmptyResponse* /*response*/, grpc::Status* status) {
+              if (!status->ok() && status->error_code() != grpc::CANCELLED) {
                 LOG_WARN("Failed to call remote VirtualObject::New");
+                connection->NotifyDisconnection();
               }
-              delete context;
-              delete request;
-              delete response;
             });
-      });
+
+    caller->request()->set_id(id);
+
+    grpc_queue->Push(std::unique_ptr<AsyncGrpcCallerBase>(caller));
+  });
 
   session_->job_queue()->Push(std::move(job));
 }
@@ -50,64 +52,64 @@ VirtualObject::Init()
 void
 VirtualObject::Commit()
 {
-  auto context = new SerialRequestContext(session_.get());
+  auto context_raw = new SerialRequestContext(session_.get());
 
-  auto job = CreateJob(
-      [id = id_, channel = session_->grpc_channel(), context](bool cancel) {
-        if (cancel) {
-          delete context;
-          return;
-        }
+  auto job = CreateJob([id = id_, connection = session_->connection(),
+                           context_raw,
+                           grpc_queue = session_->grpc_queue()](bool cancel) {
+    auto context = std::unique_ptr<grpc::ClientContext>(context_raw);
+    if (cancel) {
+      return;
+    }
 
-        auto stub = VirtualObjectService::NewStub(channel);
+    auto stub = VirtualObjectService::NewStub(connection->grpc_channel());
 
-        auto request = new VirtualObjectCommitRequest();
-        auto response = new EmptyResponse();
-
-        request->set_id(id);
-
-        stub->async()->Commit(context, request, response,
-            [context, request, response](grpc::Status status) {
-              if (!status.ok() && status.error_code() != grpc::CANCELLED) {
+    auto caller =
+        new AsyncGrpcCaller<&VirtualObjectService::Stub::PrepareAsyncCommit>(
+            std::move(stub), std::move(context),
+            [connection](EmptyResponse* /*response*/, grpc::Status* status) {
+              if (!status->ok() && status->error_code() != grpc::CANCELLED) {
                 LOG_WARN("Failed to call remote VirtualObject::Commit");
+                connection->NotifyDisconnection();
               }
-              delete context;
-              delete request;
-              delete response;
             });
-      });
+
+    caller->request()->set_id(id);
+
+    grpc_queue->Push(std::unique_ptr<AsyncGrpcCallerBase>(caller));
+  });
 
   session_->job_queue()->Push(std::move(job));
 }
 
 VirtualObject::~VirtualObject()
 {
-  auto context = new SerialRequestContext(session_.get());
+  auto context_raw = new SerialRequestContext(session_.get());
 
-  auto job = CreateJob(
-      [id = id_, channel = session_->grpc_channel(), context](bool cancel) {
-        if (cancel) {
-          delete context;
-          return;
-        }
+  auto job = CreateJob([id = id_, connection = session_->connection(),
+                           context_raw,
+                           grpc_queue = session_->grpc_queue()](bool cancel) {
+    auto context = std::unique_ptr<grpc::ClientContext>(context_raw);
+    if (cancel) {
+      return;
+    }
 
-        auto stub = VirtualObjectService::NewStub(channel);
+    auto stub = VirtualObjectService::NewStub(connection->grpc_channel());
 
-        auto request = new DeleteResourceRequest();
-        auto response = new EmptyResponse();
-
-        request->set_id(id);
-
-        stub->async()->Delete(context, request, response,
-            [context, request, response](grpc::Status status) {
-              if (!status.ok() && status.error_code() != grpc::CANCELLED) {
+    auto caller =
+        new AsyncGrpcCaller<&VirtualObjectService::Stub::PrepareAsyncDelete>(
+            std::move(stub), std::move(context),
+            [connection](EmptyResponse* /*response*/, grpc::Status* status) {
+              if (!status->ok() && status->error_code() != grpc::CANCELLED) {
                 LOG_WARN("Failed to call remote VirtualObject::Delete");
+                connection->NotifyDisconnection();
               }
-              delete context;
-              delete request;
-              delete response;
             });
-      });
+
+    caller->request()->set_id(id);
+
+    grpc_queue->Push(std::unique_ptr<AsyncGrpcCallerBase>(caller));
+  });
 
   session_->job_queue()->Push(std::move(job));
 }


### PR DESCRIPTION
## Context

Handle the situation where the gRPC channel has been broken.

## Summary

- [x] Use async gRPC client
  - Callback gRPC client (previous implementation) spawn sub-thread internally, and this causes error when destroying session.
- [x] Emit session disconnected signal when some gRPC request failed.

## How to check behavior

TBD