### PR TITLE
Ping for peer discovery

### DIFF
--- a/src/client/service/session.cc
+++ b/src/client/service/session.cc
@@ -26,9 +26,9 @@ grpc::Status
 SessionServiceImpl::New(grpc::ServerContext* /*context*/,
     const NewSessionRequest* /*request*/, NewSessionResponse* response)
 {
-  auto&& session = remote_->session_manager()->ResetCurrent();
+  auto id = remote_->session_manager()->ResetCurrent();
 
-  response->set_id(session->id());
+  response->set_id(id);
 
   return grpc::Status::OK;
 }

--- a/src/client/session-manager.h
+++ b/src/client/session-manager.h
@@ -22,8 +22,10 @@ class SessionManager {
   /**
    * Destroy current session and set new session.
    * Used in the update thread
+   *
+   * @returns id of the new session
    */
-  std::unique_ptr<Session>& ResetCurrent();
+  uint64_t ResetCurrent();
 
   /**
    * Used in the rendering thread
@@ -38,8 +40,9 @@ class SessionManager {
 
   struct {
     std::thread thread;
+    std::mutex thread_mutex;  // lock thread itself
     bool running;
-    std::mutex mutex;
+    std::mutex mutex;  // Be careful of deadlock with thread_mutex
     std::condition_variable cond;
   } broadcast_;
 

--- a/src/server/async-grpc-queue.h
+++ b/src/server/async-grpc-queue.h
@@ -9,7 +9,7 @@ struct AsyncGrpcCallerBase;
 class AsyncGrpcQueue {
  public:
   DISABLE_MOVE_AND_COPY(AsyncGrpcQueue);
-  AsyncGrpcQueue() = default;
+  AsyncGrpcQueue();
   ~AsyncGrpcQueue();
 
   void Push(std::unique_ptr<AsyncGrpcCallerBase> caller);
@@ -20,7 +20,7 @@ class AsyncGrpcQueue {
 
  private:
   std::thread thread_;
-  grpc::CompletionQueue cq_;
+  std::shared_ptr<grpc::CompletionQueue> cq_;
 };
 
 }  // namespace zen::remote::server

--- a/src/server/peer-manager.h
+++ b/src/server/peer-manager.h
@@ -21,7 +21,7 @@ class PeerManager final : public IPeerManager {
   void AcceptUdpBroadcast(int fd, uint32_t mask);
 
   std::list<std::shared_ptr<Peer>> peers_;
-  std::unique_ptr<ILoop> loop_;
+  std::shared_ptr<ILoop> loop_;
   boost::asio::io_context io_context_;
   boost::asio::ip::udp::socket udp_socket_;
   std::unique_ptr<FdSource> udp_socket_source_;

--- a/src/server/peer.cc
+++ b/src/server/peer.cc
@@ -4,7 +4,66 @@ namespace zen::remote::server {
 
 uint64_t Peer::next_id_ = 0;
 
-Peer::Peer(std::string host) : host_(host), id_(next_id_++) {}
+Peer::Peer(std::string host, std::shared_ptr<ILoop> loop)
+    : host_(host), id_(next_id_++), loop_(std::move(loop))
+{
+}
+
+Peer::~Peer()
+{
+  if (ping_timer_fd_ >= 0) loop_->RemoveFd(ping_timer_source_.get());
+}
+
+bool
+Peer::Init()
+{
+  ping_timer_fd_ = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC | TFD_NONBLOCK);
+  if (ping_timer_fd_ < 0) return false;
+
+  ping_timer_source_ = std::make_unique<FdSource>();
+  ping_timer_source_->fd = ping_timer_fd_;
+  ping_timer_source_->mask = FdSource::kReadable;
+  ping_timer_source_->callback = [this](int /*fd*/, uint32_t /*mask*/) {
+    Expire();
+  };
+
+  loop_->AddFd(ping_timer_source_.get());
+
+  return true;
+}
+
+void
+Peer::Ping()
+{
+  if (!alive_) return;
+  struct timespec deadline;
+  struct itimerspec timer;
+
+  clock_gettime(CLOCK_MONOTONIC, &deadline);
+
+  deadline.tv_nsec += (kPeerPingTimeoutMsec % 1000) * 1000000L;
+  deadline.tv_sec += kPeerPingTimeoutMsec / 1000;
+  if (deadline.tv_nsec >= 1000000000L) {
+    deadline.tv_nsec -= 1000000000L;
+    deadline.tv_sec += 1;
+  }
+
+  timer.it_interval.tv_nsec = 0;
+  timer.it_interval.tv_sec = 0;
+  timer.it_value = deadline;
+
+  if (timerfd_settime(ping_timer_fd_, TFD_TIMER_ABSTIME, &timer, NULL) != 0) {
+    Expire();
+  }
+}
+
+void
+Peer::Expire()
+{
+  if (alive_ == false) return;
+  alive_ = false;
+  on_expired();
+}
 
 std::string
 Peer::host()
@@ -16,6 +75,14 @@ uint64_t
 Peer::id()
 {
   return id_;
+}
+
+std::shared_ptr<Peer>
+CreatePeer(std::string host, std::shared_ptr<ILoop> loop)
+{
+  auto peer = std::make_shared<Peer>(host, loop);
+  if (peer->Init() == false) return std::shared_ptr<Peer>();
+  return peer;
 }
 
 }  // namespace zen::remote::server

--- a/src/server/peer.h
+++ b/src/server/peer.h
@@ -1,22 +1,40 @@
 #include "core/common.h"
+#include "zen-remote/loop.h"
 #include "zen-remote/server/peer.h"
 
 namespace zen::remote::server {
+
+constexpr uint32_t kPeerPingTimeoutMsec = 4500;
 
 class Peer final : public IPeer {
  public:
   DISABLE_MOVE_AND_COPY(Peer);
   Peer() = delete;
-  Peer(std::string host);
+  Peer(std::string host, std::shared_ptr<ILoop> loop);
+  ~Peer();
+
+  bool Init();
+
+  void Ping();
 
   std::string host() override;
   uint64_t id() override;
 
+  std::function<void()> on_expired;
+
  private:
+  void Expire();
+
   std::string host_;
   uint64_t id_;
+  std::shared_ptr<ILoop> loop_;
+  int ping_timer_fd_ = -1;
+  std::unique_ptr<FdSource> ping_timer_source_;
+  bool alive_ = true;
 
   static uint64_t next_id_;
 };
+
+std::shared_ptr<Peer> CreatePeer(std::string host, std::shared_ptr<ILoop> loop);
 
 }  // namespace zen::remote::server


### PR DESCRIPTION
## Context

Client sends UDP broadcast packet per a second.
Server should detect peer lost when the server does not get the packet for few seconds.

## Summary

- [x] When server does not receive UDP broadcast discovery packet 4.5 seconds, the server removes the peer from the peer list.

## How to check behavior

1. When restart zen-oculus, the server detect the reconnection and restart new session.