### PR TITLE
Only user owns session

### DIFF
--- a/include/zen-remote/client/remote.h
+++ b/include/zen-remote/client/remote.h
@@ -13,8 +13,6 @@ struct IRemote {
 
   virtual void Start() = 0;
 
-  virtual void Stop() = 0;
-
   virtual void UpdateScene() = 0;  // deprecated
 
   virtual void Render(Camera *camera) = 0;  // deprecated

--- a/include/zen-remote/server/session.h
+++ b/include/zen-remote/server/session.h
@@ -8,6 +8,11 @@
 
 namespace zen::remote::server {
 
+/**
+ * Session is passed to zen-remote objects as a shared_ptr, but the zen-remote
+ * objects never own the session; if the zen-remote objests have a reference to
+ * the session, it is held as a weak_ptr.
+ */
 struct ISession {
   virtual ~ISession() = default;
 

--- a/protos/session.proto
+++ b/protos/session.proto
@@ -7,11 +7,21 @@ import "common.proto";
 service SessionService
 {
   rpc New(NewSessionRequest) returns (NewSessionResponse);
+
+  rpc Ping(stream SessionPingRequest) returns (SessionTerminateResponse);
 }
 
 message NewSessionRequest {}
 
 message NewSessionResponse
 {
-  uint64 id = 1;
+  uint64 id = 1;  // session id
 }
+
+message SessionPingRequest
+{
+  uint64 id = 1;  // session id
+  bool done = 2;  // workaround for https://github.com/grpc/grpc/issues/10136
+}
+
+message SessionTerminateResponse {}

--- a/src/client/grpc-server.cc
+++ b/src/client/grpc-server.cc
@@ -51,9 +51,13 @@ GrpcServer::Start()
     bool ok = true;
     for (;;) {
       if (completion_queue_->Next(&tag, &ok) == false) break;
-      if (!ok) continue;
+      auto caller = static_cast<service::IAsyncServiceCaller *>(tag);
+      if (!ok) {
+        caller->Cancel();
+        continue;
+      }
 
-      static_cast<service::IAsyncSessionServiceCaller *>(tag)->Proceed();
+      caller->Proceed();
     }
   });
 }

--- a/src/client/grpc-server.cc
+++ b/src/client/grpc-server.cc
@@ -51,13 +51,10 @@ GrpcServer::Start()
     bool ok = true;
     for (;;) {
       if (completion_queue_->Next(&tag, &ok) == false) break;
-      if (!ok) {
-        LOG_ERROR("Failed to poll gRPC queue");
-        break;
-      }
+      if (!ok) continue;
+
       static_cast<service::IAsyncSessionServiceCaller *>(tag)->Proceed();
     }
-    // FIXME: Some SerialAsyncCallers should not be deleted
   });
 }
 

--- a/src/client/grpc-server.cc
+++ b/src/client/grpc-server.cc
@@ -51,13 +51,14 @@ GrpcServer::Start()
     bool ok = true;
     for (;;) {
       if (completion_queue_->Next(&tag, &ok) == false) break;
-      auto caller = static_cast<service::IAsyncServiceCaller *>(tag);
-      if (!ok) {
-        caller->Cancel();
-        continue;
-      }
 
-      caller->Proceed();
+      auto caller = static_cast<service::IAsyncServiceCaller *>(tag);
+
+      if (ok) {
+        caller->Proceed();
+      } else {
+        caller->Cancel();
+      }
     }
   });
 }
@@ -65,7 +66,7 @@ GrpcServer::Start()
 GrpcServer::~GrpcServer()
 {
   if (thread_.joinable() && server_) {
-    server_->Shutdown();
+    server_->Shutdown(std::chrono::system_clock::now());
     completion_queue_->Shutdown();
     thread_.join();
   }

--- a/src/client/remote.cc
+++ b/src/client/remote.cc
@@ -20,12 +20,6 @@ Remote::Start()
 }
 
 void
-Remote::Stop()
-{
-  // TODO:
-}
-
-void
 Remote::UpdateScene()
 {
   auto pool = session_manager_.GetCurrentResourcePool();

--- a/src/client/remote.h
+++ b/src/client/remote.h
@@ -16,8 +16,6 @@ class Remote : public IRemote {
 
   void Start() override;
 
-  void Stop() override;
-
   /** Call only once before rendering for multiple cameras. */
   void UpdateScene() override;
 

--- a/src/client/service/async-service-caller.h
+++ b/src/client/service/async-service-caller.h
@@ -10,6 +10,7 @@ namespace zen::remote::client::service {
 struct IAsyncServiceCaller {
   virtual ~IAsyncServiceCaller() = default;
   virtual void Proceed() = 0;
+  virtual void Cancel() = 0;
 };
 
 template <auto AsyncServiceRequest, auto Handler>
@@ -59,6 +60,8 @@ class AsyncServiceCaller final : public IAsyncServiceCaller {
       delete this;
     }
   }
+
+  void Cancel() override { delete this; }
 
  private:
   AsyncServiceCaller(AsyncService *async_service, ServiceImpl *service_impl,

--- a/src/client/service/async-session-ping-caller.h
+++ b/src/client/service/async-session-ping-caller.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "client/remote.h"
+#include "client/service/async-service.h"
+#include "session.grpc.pb.h"
+
+namespace zen::remote::client::service {
+
+class AsyncSessionPingCaller {
+  enum State {
+    kCreate = 0,
+    kConnect,
+    kRead,
+    kFinish,
+  };
+
+  struct Tag final : public IAsyncServiceCaller {
+    State type;
+    AsyncSessionPingCaller* caller;
+
+    Tag(State type, AsyncSessionPingCaller* caller) : type(type), caller(caller)
+    {
+    }
+
+    void Proceed() override { caller->Proceed(type); }
+
+    void Cancel() override { caller->Cancel(); }
+  };
+
+ public:
+  static void Listen(SessionService::AsyncService* async_service,
+      grpc::ServerCompletionQueue* completion_queue, Remote* remote)
+  {
+    new AsyncSessionPingCaller(async_service, completion_queue, remote);
+  }
+
+ private:
+  void Proceed(State state)
+  {
+    switch (state) {
+      case kCreate:
+        async_service_->RequestPing(&context_, &reader_, completion_queue_,
+            completion_queue_, &connect_tag_);
+        return;
+
+      case kConnect:
+        new AsyncSessionPingCaller(async_service_, completion_queue_, remote_);
+        reader_.Read(&request_, &read_tag_);
+        return;
+
+      case kRead:
+        session_id_ = request_.id();
+        if (request_.done()) {
+          SessionTerminateResponse response;
+          reader_.Finish(response, grpc::Status::OK, &finish_tag_);
+        } else {
+          reader_.Read(&request_, &read_tag_);
+        }
+        return;
+
+      case kFinish:
+        delete this;
+        return;
+
+      default:
+        assert(false && "Unexpected state");
+        return;
+    }
+  }
+
+  void Cancel() { delete this; }
+
+  AsyncSessionPingCaller(SessionService::AsyncService* async_service,
+      grpc::ServerCompletionQueue* completion_queue, Remote* remote)
+      : async_service_(async_service),
+        remote_(remote),
+        completion_queue_(completion_queue),
+        reader_(&context_),
+        connect_tag_(kConnect, this),
+        read_tag_(kRead, this),
+        finish_tag_(kFinish, this)
+  {
+    Proceed(kCreate);
+  }
+
+  ~AsyncSessionPingCaller()
+  {
+    if (remote_->session_manager()->current() &&
+        session_id_ == remote_->session_manager()->current()->id()) {
+      remote_->session_manager()->ClearCurrent();
+    }
+  }
+
+  SessionPingRequest request_;
+
+  SessionService::AsyncService* async_service_;
+  Remote* remote_;
+  grpc::ServerCompletionQueue* completion_queue_;
+  grpc::ServerContext context_;
+  grpc::ServerAsyncReader<SessionTerminateResponse, SessionPingRequest> reader_;
+  Tag connect_tag_;
+  Tag read_tag_;
+  Tag finish_tag_;
+  uint64_t session_id_ = 0;
+};
+
+}  // namespace zen::remote::client::service

--- a/src/client/service/async-session-service-caller.h
+++ b/src/client/service/async-session-service-caller.h
@@ -1,23 +1,19 @@
 #pragma once
 
 #include "client/remote.h"
+#include "client/service/async-service-caller.h"
 #include "client/session.h"
 #include "core/common.h"
 #include "core/logger.h"
 
 namespace zen::remote::client::service {
 
-struct IAsyncSessionServiceCaller {
-  virtual ~IAsyncSessionServiceCaller() = default;
-  virtual void Proceed() = 0;
-};
-
 /**
  * Handler implementation will be called only when the current session exists
  * and the request is for the session
  */
 template <auto AsyncServiceRequest, auto Handler>
-class AsyncSessionServiceCaller final : public IAsyncSessionServiceCaller {
+class AsyncSessionServiceCaller final : public IAsyncServiceCaller {
   enum State {
     kCreate,
     kProcess,
@@ -94,6 +90,8 @@ class AsyncSessionServiceCaller final : public IAsyncSessionServiceCaller {
       delete this;
     }
   }
+
+  void Cancel() override { delete this; }
 
  private:
   AsyncSessionServiceCaller(AsyncService *async_service,

--- a/src/client/service/session.cc
+++ b/src/client/service/session.cc
@@ -2,6 +2,7 @@
 
 #include "client/remote.h"
 #include "client/service/async-service-caller.h"
+#include "client/service/async-session-ping-caller.h"
 #include "client/session.h"
 
 namespace zen::remote::client::service {
@@ -20,6 +21,8 @@ SessionServiceImpl::Listen(grpc::ServerCompletionQueue* completion_queue)
   AsyncServiceCaller<&SessionService::AsyncService::RequestNew,
       &SessionServiceImpl::New>::Listen(&async_, this, completion_queue,
       remote_);
+
+  AsyncSessionPingCaller::Listen(&async_, completion_queue, remote_);
 }
 
 grpc::Status

--- a/src/client/session-manager.cc
+++ b/src/client/session-manager.cc
@@ -40,6 +40,21 @@ SessionManager::ResetCurrent()
   return id;
 }
 
+void
+SessionManager::ClearCurrent()
+{
+  {
+    std::lock_guard<std::mutex> lock(current_mutex_);
+    if (!current_) return;
+    current_.reset();
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(broadcast_.thread_mutex);
+    StartDiscoverBroadcast();
+  }
+}
+
 std::shared_ptr<ResourcePool>
 SessionManager::GetCurrentResourcePool()
 {

--- a/src/client/session-manager.h
+++ b/src/client/session-manager.h
@@ -28,6 +28,12 @@ class SessionManager {
   uint64_t ResetCurrent();
 
   /**
+   * Destroy current session and start discovery UDP broadcast
+   * Used in the update thread
+   */
+  void ClearCurrent();
+
+  /**
    * Used in the rendering thread
    *
    * @returns null if no current session exists.

--- a/src/server/gl-base-technique.cc
+++ b/src/server/gl-base-technique.cc
@@ -12,17 +12,20 @@
 namespace zen::remote::server {
 
 GlBaseTechnique::GlBaseTechnique(std::shared_ptr<Session> session)
-    : session_(std::move(session)), id_(session_->NewSerial(Session::kResource))
+    : id_(session->NewSerial(Session::kResource)), session_(std::move(session))
 {
 }
 
 void
 GlBaseTechnique::Init(uint64_t rendering_unit_id)
 {
-  auto context_raw = new SerialRequestContext(session_.get());
+  auto session = session_.lock();
+  if (!session) return;
 
-  auto job = CreateJob([id = id_, connection = session_->connection(),
-                           context_raw, grpc_queue = session_->grpc_queue(),
+  auto context_raw = new SerialRequestContext(session.get());
+
+  auto job = CreateJob([id = id_, connection = session->connection(),
+                           context_raw, grpc_queue = session->grpc_queue(),
                            rendering_unit_id](bool cancel) {
     auto context = std::unique_ptr<grpc::ClientContext>(context_raw);
     if (cancel) {
@@ -47,52 +50,58 @@ GlBaseTechnique::Init(uint64_t rendering_unit_id)
     grpc_queue->Push(std::unique_ptr<AsyncGrpcCallerBase>(caller));
   });
 
-  session_->job_queue()->Push(std::move(job));
+  session->job_queue()->Push(std::move(job));
 }
 
 void
 GlBaseTechnique::GlDrawArrays(uint32_t mode, int32_t first, uint32_t count)
 {
-  auto context_raw = new SerialRequestContext(session_.get());
+  auto session = session_.lock();
+  if (!session) return;
 
-  auto job = CreateJob([id = id_, connection = session_->connection(),
-                           context_raw, grpc_queue = session_->grpc_queue(),
-                           mode, first, count](bool cancel) {
-    auto context = std::unique_ptr<grpc::ClientContext>(context_raw);
-    if (cancel) {
-      return;
-    }
+  auto context_raw = new SerialRequestContext(session.get());
 
-    auto stub = GlBaseTechniqueService::NewStub(connection->grpc_channel());
+  auto job = CreateJob(
+      [id = id_, connection = session->connection(), context_raw,
+          grpc_queue = session->grpc_queue(), mode, first, count](bool cancel) {
+        auto context = std::unique_ptr<grpc::ClientContext>(context_raw);
+        if (cancel) {
+          return;
+        }
 
-    auto caller = new AsyncGrpcCaller<
-        &GlBaseTechniqueService::Stub::PrepareAsyncGlDrawArrays>(
-        std::move(stub), std::move(context),
-        [connection](EmptyResponse* /*response*/, grpc::Status* status) {
-          if (!status->ok() && status->error_code() != grpc::CANCELLED) {
-            LOG_WARN("Failed to call remote GlBaseTechnique::GlDrawArrays");
-            connection->NotifyDisconnection();
-          }
-        });
+        auto stub = GlBaseTechniqueService::NewStub(connection->grpc_channel());
 
-    caller->request()->set_id(id);
-    caller->request()->set_mode(mode);
-    caller->request()->set_first(first);
-    caller->request()->set_count(count);
+        auto caller = new AsyncGrpcCaller<
+            &GlBaseTechniqueService::Stub::PrepareAsyncGlDrawArrays>(
+            std::move(stub), std::move(context),
+            [connection](EmptyResponse* /*response*/, grpc::Status* status) {
+              if (!status->ok() && status->error_code() != grpc::CANCELLED) {
+                LOG_WARN("Failed to call remote GlBaseTechnique::GlDrawArrays");
+                connection->NotifyDisconnection();
+              }
+            });
 
-    grpc_queue->Push(std::unique_ptr<AsyncGrpcCallerBase>(caller));
-  });
+        caller->request()->set_id(id);
+        caller->request()->set_mode(mode);
+        caller->request()->set_first(first);
+        caller->request()->set_count(count);
 
-  session_->job_queue()->Push(std::move(job));
+        grpc_queue->Push(std::unique_ptr<AsyncGrpcCallerBase>(caller));
+      });
+
+  session->job_queue()->Push(std::move(job));
 }
 
 GlBaseTechnique::~GlBaseTechnique()
 {
-  auto context_raw = new SerialRequestContext(session_.get());
+  auto session = session_.lock();
+  if (!session) return;
 
-  auto job = CreateJob([id = id_, connection = session_->connection(),
+  auto context_raw = new SerialRequestContext(session.get());
+
+  auto job = CreateJob([id = id_, connection = session->connection(),
                            context_raw,
-                           grpc_queue = session_->grpc_queue()](bool cancel) {
+                           grpc_queue = session->grpc_queue()](bool cancel) {
     auto context = std::unique_ptr<grpc::ClientContext>(context_raw);
     if (cancel) {
       return;
@@ -115,7 +124,7 @@ GlBaseTechnique::~GlBaseTechnique()
     grpc_queue->Push(std::unique_ptr<AsyncGrpcCallerBase>(caller));
   });
 
-  session_->job_queue()->Push(std::move(job));
+  session->job_queue()->Push(std::move(job));
 }
 
 uint64_t

--- a/src/server/gl-base-technique.h
+++ b/src/server/gl-base-technique.h
@@ -19,8 +19,8 @@ class GlBaseTechnique final : public IGlBaseTechnique {
   uint64_t id() override;
 
  private:
-  std::shared_ptr<Session> session_;
   uint64_t id_;
+  std::weak_ptr<Session> session_;
 };
 
 }  // namespace zen::remote::server

--- a/src/server/gl-buffer.h
+++ b/src/server/gl-buffer.h
@@ -22,8 +22,8 @@ class GlBuffer final : public IGlBuffer {
   uint64_t id() override;
 
  private:
-  std::shared_ptr<Session> session_;
   uint64_t id_;
+  std::weak_ptr<Session> session_;
 };
 
 }  // namespace zen::remote::server

--- a/src/server/rendering-unit.h
+++ b/src/server/rendering-unit.h
@@ -22,8 +22,8 @@ class RenderingUnit final : public IRenderingUnit {
   uint64_t id() override;
 
  private:
-  std::shared_ptr<Session> session_;
   uint64_t id_;
+  std::weak_ptr<Session> session_;
 };
 
 }  // namespace zen::remote::server

--- a/src/server/session-connection.h
+++ b/src/server/session-connection.h
@@ -6,8 +6,9 @@ namespace zen::remote::server {
 
 class SessionConnection {
  public:
-  enum ConnectionControl : uint8_t {
-    kDisconnect = 0,
+  enum ControlMessage : uint8_t {
+    kError = 0,
+    kDisconnect,
   };
 
   DISABLE_MOVE_AND_COPY(SessionConnection);

--- a/src/server/session.cc
+++ b/src/server/session.cc
@@ -16,6 +16,8 @@ Session::Session(std::unique_ptr<ILoop> loop) : loop_(std::move(loop))
 
 Session::~Session()
 {
+  StopPingThread();
+
   /**
    * Terminate job queue first so that no additional work is enqueued to
    * grpc_queue after termination.
@@ -63,25 +65,141 @@ Session::Connect(std::shared_ptr<IPeer> peer)
     return false;
   }
 
+  id_ = response.id();
+
+  StartPingThread();
+
   control_event_source_ = new FdSource();
 
   control_event_source_->fd = pipe_[0];
   control_event_source_->mask = FdSource::kReadable;
-  control_event_source_->callback = [this](int /*fd*/, uint32_t /*mask*/) {
-    if (connected_ == false) return;
-    connected_ = false;
-    this->connection_->Disable();
-    this->on_disconnect();  // this may destroy self
+  control_event_source_->callback = [this](int fd, uint32_t /*mask*/) {
+    SessionConnection::ControlMessage message = SessionConnection::kError;
+    read(fd, &message, sizeof(message));
+
+    HandleControlEvent(message);  // this may destroy self
   };
 
   loop_->AddFd(control_event_source_);
 
-  id_ = response.id();
   connected_ = true;
 
   job_queue_.StartWorkerThread();
 
   return true;
+}
+
+/**
+ * Excuse: This is a stopgap implementation to prioritize other parts of the
+ * development. It can use keepalive of gRPC or be more concise implementation.
+ */
+void
+Session::StartPingThread()
+{
+  if (ping_thread_.joinable()) return;
+
+  should_ping_ = true;
+
+  ping_thread_ = std::thread([this, id = id_, connection = connection_] {
+    auto cq = std::make_shared<grpc::CompletionQueue>();
+
+    auto stub = SessionService::NewStub(connection->grpc_channel());
+
+    grpc::ClientContext context;
+    grpc::Status status;
+    SessionTerminateResponse response;
+
+    bool finished = false;
+    std::mutex finish_mutex;
+    std::condition_variable finish_cond;
+
+    auto writer = stub->AsyncPing(&context, &response, cq.get(), NULL);
+
+    auto completion_thread =
+        std::thread([cq, &finish_mutex, &finish_cond, &finished, connection] {
+          void *tag;
+          bool ok = false;
+
+          while (cq->Next(&tag, &ok)) {
+            if (!ok) {
+              connection->NotifyDisconnection();
+            }
+            if ((bool)tag) {  // finished
+              {
+                std::lock_guard<std::mutex> lock(finish_mutex);
+                finished = true;
+              }
+              finish_cond.notify_one();
+            }
+          }
+        });
+
+    SessionPingRequest request;
+    SessionPingRequest done_request;
+
+    writer->Finish(&status, (void *)true);
+
+    int i = 0;
+    for (;;) {
+      i++;
+      std::unique_lock<std::mutex> lock(ping_mutex_);
+
+      {
+        request.set_id(id);
+        request.set_done(false);
+        writer->Write(request, (void *)false);
+      }
+
+      ping_cond_.wait_for(lock, std::chrono::seconds(1),
+          [this] { return should_ping_ == false; });
+
+      if (should_ping_ == false) {
+        done_request.set_id(id);
+        done_request.set_done(true);
+        writer->Write(done_request, (void *)false);
+        break;
+      };
+    }
+
+    std::unique_lock<std::mutex> lock(finish_mutex);
+
+    finish_cond.wait_for(
+        lock, std::chrono::microseconds(100), [&finished] { return finished; });
+
+    cq->Shutdown();
+
+    completion_thread.detach();
+  });
+}
+
+void
+Session::StopPingThread()
+{
+  {
+    std::lock_guard<std::mutex> lock(ping_mutex_);
+    should_ping_ = false;
+  }
+
+  ping_cond_.notify_one();
+
+  ping_thread_.join();
+}
+
+void
+Session::HandleControlEvent(SessionConnection::ControlMessage message)
+{
+  switch (message) {
+    case SessionConnection::kDisconnect:  // fall through
+    case SessionConnection::kError:
+      if (connected_ == false) return;
+      connected_ = false;
+      this->connection_->Disable();
+      this->on_disconnect();  // this may destroy self
+      return;
+
+    default:
+      break;
+  }
 }
 
 uint64_t

--- a/src/server/virtual-object.h
+++ b/src/server/virtual-object.h
@@ -21,8 +21,8 @@ class VirtualObject final : public IVirtualObject {
   uint64_t id() override;
 
  private:
-  std::shared_ptr<Session> session_;
   uint64_t id_;
+  std::weak_ptr<Session> session_;
 };
 
 }  // namespace zen::remote::server


### PR DESCRIPTION
## Context

refactor session to be able to handle reconnection.

## Summary

- [x] Stop zen-remote objects to have an ownership of session, instead, only user (zen) has an ownership.
- [x] Refactor gRPC async service caller not to leak memory.
- [x] Implement ping for session to detect disconnection. (makeshift)  

## How to check behavior

1. Restart zen or zen-oculus
2. In the log, you can confirm that the new session started when reconnected.