### PR TITLE
fix glBufferData arg types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(
   LANGUAGES C CXX
   HOMEPAGE_URL https://github.com/zigen-project/zen-remote
   DESCRIPTION "Library for ZEN to communicate with devices over a network"
-  VERSION 0.1.0.11
+  VERSION 0.1.0.12
 )
 
 set(CMAKE_CXX_STANDARD 17)

--- a/include/zen-remote/server/gl-buffer.h
+++ b/include/zen-remote/server/gl-buffer.h
@@ -10,8 +10,8 @@ namespace zen::remote::server {
 struct IGlBuffer {
   virtual ~IGlBuffer() = default;
 
-  virtual void GlBufferData(std::unique_ptr<IBuffer> buffer, uint64_t target,
-      size_t size, uint64_t usage) = 0;
+  virtual void GlBufferData(std::unique_ptr<IBuffer> buffer, uint32_t target,
+      size_t size, uint32_t usage) = 0;
 
   virtual uint64_t id() = 0;
 };

--- a/protos/gl-buffer.proto
+++ b/protos/gl-buffer.proto
@@ -16,7 +16,7 @@ service GlBufferService
 message GlBufferDataRequest
 {
   uint64 id = 1;
-  uint64 target = 2;
-  uint64 usage = 3;
+  uint32 target = 2;
+  uint32 usage = 3;
   bytes data = 4;
 }

--- a/src/client/gl-buffer.h
+++ b/src/client/gl-buffer.h
@@ -19,13 +19,13 @@ class GlBuffer final : public IResource {
 
   /** Used in the update thread */
   void GlBufferData(
-      const void *data, uint64_t target, size_t size, uint64_t usage);
+      const void *data, uint32_t target, size_t size, uint32_t usage);
 
   uint64_t id() override;
 
   /** Used in the rendering thread */
   inline GLuint buffer_id();
-  inline uint64_t target();
+  inline uint32_t target();
 
  private:
   const uint64_t id_;
@@ -36,8 +36,8 @@ class GlBuffer final : public IResource {
     size_t size = 0;
     size_t alloc = 0;
 
-    uint64_t target;
-    uint64_t usage;
+    uint32_t target;
+    uint32_t usage;
 
     bool data_damaged = false;
   } pending_;
@@ -45,7 +45,7 @@ class GlBuffer final : public IResource {
   struct {
     GLuint buffer_id = 0;
 
-    uint64_t target;
+    uint32_t target;
   } rendering_;
 };
 
@@ -55,7 +55,7 @@ GlBuffer::buffer_id()
   return rendering_.buffer_id;
 }
 
-inline uint64_t
+inline uint32_t
 GlBuffer::target()
 {
   return rendering_.target;

--- a/src/server/gl-buffer.cc
+++ b/src/server/gl-buffer.cc
@@ -53,8 +53,8 @@ GlBuffer::Init()
 }
 
 void
-GlBuffer::GlBufferData(std::unique_ptr<IBuffer> buffer, uint64_t target,
-    size_t size, uint64_t usage)
+GlBuffer::GlBufferData(std::unique_ptr<IBuffer> buffer, uint32_t target,
+    size_t size, uint32_t usage)
 {
   auto session = session_.lock();
   if (!session) return;

--- a/src/server/gl-buffer.h
+++ b/src/server/gl-buffer.h
@@ -16,8 +16,8 @@ class GlBuffer final : public IGlBuffer {
 
   void Init();
 
-  void GlBufferData(std::unique_ptr<IBuffer> buffer, uint64_t target,
-      size_t size, uint64_t usage) override;
+  void GlBufferData(std::unique_ptr<IBuffer> buffer, uint32_t target,
+      size_t size, uint32_t usage) override;
 
   uint64_t id() override;
 


### PR DESCRIPTION
make glBufferData client process efficient

## Context

We decided to use uint32_t for GLenum type. This pull request adapt to it regarding glBufferData request.

And also fixed inefficient process in glBufferData request process in client.

## Summary

- [x] fix argument types of gRPC GlBufferData request.
- [x] fix inefficient process in glBufferData request process in client. 
