### PR TITLE
add constructor and destructor of vertex array

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(
   LANGUAGES C CXX
   HOMEPAGE_URL https://github.com/zigen-project/zen-remote
   DESCRIPTION "Library for ZEN to communicate with devices over a network"
-  VERSION 0.1.0.12
+  VERSION 0.1.0.13
 )
 
 set(CMAKE_CXX_STANDARD 17)

--- a/include/zen-remote/server/gl-vertex-array.h
+++ b/include/zen-remote/server/gl-vertex-array.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <zen-remote/server/session.h>
+
+#include <memory>
+
+namespace zen::remote::server {
+
+struct IGlVertexArray {
+  virtual ~IGlVertexArray() = default;
+};
+
+std::unique_ptr<IGlVertexArray> CreateGlVertexArray(
+    std::shared_ptr<ISession> session);
+
+}  // namespace zen::remote::server

--- a/protos/CMakeLists.txt
+++ b/protos/CMakeLists.txt
@@ -24,6 +24,7 @@ set(protos
   "common"
   "gl-base-technique"
   "gl-buffer"
+  "gl-vertex-array"
   "rendering-unit"
   "session"
   "virtual-object"

--- a/protos/gl-vertex-array.proto
+++ b/protos/gl-vertex-array.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package zen.remote;
+
+import "common.proto";
+
+service GlVertexArrayService
+{
+  rpc New(NewResourceRequest) returns (EmptyResponse);
+
+  rpc Delete(DeleteResourceRequest) returns (EmptyResponse);
+}

--- a/src/client/gl-vertex-array.cc
+++ b/src/client/gl-vertex-array.cc
@@ -1,0 +1,26 @@
+#include "client/gl-vertex-array.h"
+
+#include "client/atomic-command-queue.h"
+
+namespace zen::remote::client {
+
+GlVertexArray::GlVertexArray(
+    uint64_t id, AtomicCommandQueue *update_rendering_queue)
+    : id_(id), update_rendering_queue_(update_rendering_queue)
+{
+}
+
+void
+GlVertexArray::Commit()
+{
+  // TODO:
+  (void)update_rendering_queue_;
+}
+
+uint64_t
+GlVertexArray::id()
+{
+  return id_;
+}
+
+}  // namespace zen::remote::client

--- a/src/client/gl-vertex-array.h
+++ b/src/client/gl-vertex-array.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "client/resource.h"
+#include "core/common.h"
+
+namespace zen::remote::client {
+
+class AtomicCommandQueue;
+
+class GlVertexArray final : public IResource {
+ public:
+  DISABLE_MOVE_AND_COPY(GlVertexArray);
+  GlVertexArray() = delete;
+  GlVertexArray(uint64_t id, AtomicCommandQueue *update_rendering_queue);
+
+  void Commit();
+
+  uint64_t id() override;
+
+ private:
+  const uint64_t id_;
+  AtomicCommandQueue *update_rendering_queue_;
+};
+
+}  // namespace zen::remote::client

--- a/src/client/grpc-server.cc
+++ b/src/client/grpc-server.cc
@@ -3,6 +3,7 @@
 #include "client/service/async-session-service-caller.h"
 #include "client/service/gl-base-technique.h"
 #include "client/service/gl-buffer.h"
+#include "client/service/gl-vertex-array.h"
 #include "client/service/rendering-unit.h"
 #include "client/service/session.h"
 #include "client/service/virtual-object.h"
@@ -32,6 +33,7 @@ GrpcServer::Start()
     services.emplace_back(new service::GlBufferServiceImpl(remote_));
     services.emplace_back(new service::GlBaseTechniqueServiceImpl(remote_));
     services.emplace_back(new service::SessionServiceImpl(remote_));
+    services.emplace_back(new service::GlVertexArrayServiceImpl(remote_));
 
     for (auto &service : services) {
       service->Register(builder);

--- a/src/client/resource-pool.h
+++ b/src/client/resource-pool.h
@@ -3,6 +3,7 @@
 #include "client/atomic-command-queue.h"
 #include "client/gl-base-technique.h"
 #include "client/gl-buffer.h"
+#include "client/gl-vertex-array.h"
 #include "client/rendering-unit.h"
 #include "client/resource-container.h"
 #include "client/virtual-object.h"
@@ -18,6 +19,9 @@ using RenderingUnitContainer =
 
 using GlBufferContainer =
     ResourceContainer<GlBuffer, ResourceContainerType::kFindByIdIntensive>;
+
+using GlVertexArrayContainer =
+    ResourceContainer<GlVertexArray, ResourceContainerType::kFindByIdIntensive>;
 
 using GlBaseTechniqueContainer = ResourceContainer<GlBaseTechnique,
     ResourceContainerType::kFindByIdIntensive>;
@@ -49,6 +53,7 @@ class ResourcePool {
   inline VirtualObjectContainer *virtual_objects();
   inline RenderingUnitContainer *rendering_units();
   inline GlBufferContainer *gl_buffers();
+  inline GlVertexArrayContainer *gl_vertex_arrays();
   inline GlBaseTechniqueContainer *gl_base_techniques();
 
   /** Commands to update rendering state of resources */
@@ -58,6 +63,7 @@ class ResourcePool {
   VirtualObjectContainer virtual_objects_;
   RenderingUnitContainer rendering_units_;
   GlBufferContainer gl_buffers_;
+  GlVertexArrayContainer gl_vertex_arrays_;
   GlBaseTechniqueContainer gl_base_techniques_;
 
   AtomicCommandQueue update_rendering_queue_;
@@ -79,6 +85,12 @@ inline GlBufferContainer *
 ResourcePool::gl_buffers()
 {
   return &gl_buffers_;
+}
+
+inline GlVertexArrayContainer *
+ResourcePool::gl_vertex_arrays()
+{
+  return &gl_vertex_arrays_;
 }
 
 inline GlBaseTechniqueContainer *

--- a/src/client/service/gl-vertex-array.cc
+++ b/src/client/service/gl-vertex-array.cc
@@ -1,0 +1,58 @@
+#include "client/service/gl-vertex-array.h"
+
+#include "client/remote.h"
+#include "client/resource-pool.h"
+#include "client/service/async-session-service-caller.h"
+#include "client/session.h"
+
+namespace zen::remote::client::service {
+
+GlVertexArrayServiceImpl::GlVertexArrayServiceImpl(Remote* remote)
+    : remote_(remote)
+{
+}
+
+void
+GlVertexArrayServiceImpl::Register(grpc::ServerBuilder& builder)
+{
+  builder.RegisterService(&async_);
+}
+
+void
+GlVertexArrayServiceImpl::Listen(grpc::ServerCompletionQueue* completion_queue)
+{
+  AsyncSessionServiceCaller<&GlVertexArrayService::AsyncService::RequestNew,
+      &GlVertexArrayServiceImpl::New>::Listen(&async_, this, completion_queue,
+      remote_);
+
+  AsyncSessionServiceCaller<&GlVertexArrayService::AsyncService::RequestDelete,
+      &GlVertexArrayServiceImpl::Delete>::Listen(&async_, this,
+      completion_queue, remote_);
+}
+
+grpc::Status
+GlVertexArrayServiceImpl::New(grpc::ServerContext* /*context*/,
+    const NewResourceRequest* request, EmptyResponse* /*response*/)
+{
+  auto pool = remote_->session_manager()->current()->pool();
+
+  auto gl_vertex_array = std::make_unique<GlVertexArray>(
+      request->id(), pool->update_rendering_queue());
+
+  pool->gl_vertex_arrays()->Add(std::move(gl_vertex_array));
+
+  return grpc::Status::OK;
+}
+
+grpc::Status
+GlVertexArrayServiceImpl::Delete(grpc::ServerContext* /*context*/,
+    const DeleteResourceRequest* request, EmptyResponse* /*response*/)
+{
+  auto pool = remote_->session_manager()->current()->pool();
+
+  pool->gl_vertex_arrays()->ScheduleRemove(request->id());
+
+  return grpc::Status::OK;
+}
+
+}  // namespace zen::remote::client::service

--- a/src/client/service/gl-vertex-array.h
+++ b/src/client/service/gl-vertex-array.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "client/service/async-service.h"
+#include "core/common.h"
+#include "gl-vertex-array.grpc.pb.h"
+
+namespace zen::remote::client {
+class Remote;
+}  // namespace zen::remote::client
+
+namespace zen::remote::client::service {
+
+class GlVertexArrayServiceImpl final : public GlVertexArrayService::Service,
+                                       public IAsyncService {
+ public:
+  DISABLE_MOVE_AND_COPY(GlVertexArrayServiceImpl);
+  GlVertexArrayServiceImpl() = delete;
+  GlVertexArrayServiceImpl(Remote* remote);
+
+  void Register(grpc::ServerBuilder& builder) override;
+
+  void Listen(grpc::ServerCompletionQueue* completion_queue) override;
+
+  grpc::Status New(grpc::ServerContext* context,
+      const NewResourceRequest* request, EmptyResponse* response) override;
+
+  grpc::Status Delete(grpc::ServerContext* context,
+      const DeleteResourceRequest* request, EmptyResponse* response) override;
+
+ private:
+  GlVertexArrayService::AsyncService async_;
+  Remote* remote_;
+};
+
+}  // namespace zen::remote::client::service

--- a/src/server/gl-vertex-array.cc
+++ b/src/server/gl-vertex-array.cc
@@ -1,0 +1,99 @@
+#include "server/gl-vertex-array.h"
+
+#include "core/logger.h"
+#include "gl-vertex-array.grpc.pb.h"
+#include "server/async-grpc-caller.h"
+#include "server/async-grpc-queue.h"
+#include "server/job.h"
+#include "server/serial-request-context.h"
+#include "server/session.h"
+
+namespace zen::remote::server {
+
+GlVertexArray::GlVertexArray(std::shared_ptr<Session> session)
+    : id_(session->NewSerial(Session::kResource)), session_(std::move(session))
+{
+}
+
+void
+GlVertexArray::Init()
+{
+  auto session = session_.lock();
+  if (!session) return;
+
+  auto context_raw = new SerialRequestContext(session.get());
+
+  auto job = CreateJob([id = id_, connection = session->connection(),
+                           context_raw,
+                           grpc_queue = session->grpc_queue()](bool cancel) {
+    auto context = std::unique_ptr<grpc::ClientContext>(context_raw);
+    if (cancel) {
+      return;
+    }
+
+    auto stub = GlVertexArrayService::NewStub(connection->grpc_channel());
+
+    auto caller =
+        new AsyncGrpcCaller<&GlVertexArrayService::Stub::PrepareAsyncNew>(
+            std::move(stub), std::move(context),
+            [connection](EmptyResponse* /*response*/, grpc::Status* status) {
+              if (!status->ok() && status->error_code() != grpc::CANCELLED) {
+                LOG_WARN("Failed to call remote GlVertexArray::New");
+                connection->NotifyDisconnection();
+              }
+            });
+
+    caller->request()->set_id(id);
+
+    grpc_queue->Push(std::unique_ptr<AsyncGrpcCallerBase>(caller));
+  });
+
+  session->job_queue()->Push(std::move(job));
+}
+
+GlVertexArray::~GlVertexArray()
+{
+  auto session = session_.lock();
+  if (!session) return;
+
+  auto context_raw = new SerialRequestContext(session.get());
+
+  auto job = CreateJob([id = id_, connection = session->connection(),
+                           context_raw,
+                           grpc_queue = session->grpc_queue()](bool cancel) {
+    auto context = std::unique_ptr<grpc::ClientContext>(context_raw);
+    if (cancel) {
+      return;
+    }
+
+    auto stub = GlVertexArrayService::NewStub(connection->grpc_channel());
+
+    auto caller =
+        new AsyncGrpcCaller<&GlVertexArrayService::Stub::PrepareAsyncDelete>(
+            std::move(stub), std::move(context),
+            [connection](EmptyResponse* /*response*/, grpc::Status* status) {
+              if (!status->ok() && status->error_code() != grpc::CANCELLED) {
+                LOG_WARN("Failed to call remote GlVertexArray::Delete");
+                connection->NotifyDisconnection();
+              }
+            });
+
+    caller->request()->set_id(id);
+
+    grpc_queue->Push(std::unique_ptr<AsyncGrpcCallerBase>(caller));
+  });
+
+  session->job_queue()->Push(std::move(job));
+}
+
+std::unique_ptr<IGlVertexArray>
+CreateGlVertexArray(std::shared_ptr<ISession> session)
+{
+  auto gl_buffer = std::make_unique<GlVertexArray>(
+      std::dynamic_pointer_cast<Session>(session));
+  gl_buffer->Init();
+
+  return gl_buffer;
+}
+
+}  // namespace zen::remote::server

--- a/src/server/gl-vertex-array.h
+++ b/src/server/gl-vertex-array.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "core/common.h"
+#include "zen-remote/server/gl-vertex-array.h"
+
+namespace zen::remote::server {
+
+class Session;
+
+class GlVertexArray final : public IGlVertexArray {
+ public:
+  DISABLE_MOVE_AND_COPY(GlVertexArray);
+  GlVertexArray() = delete;
+  GlVertexArray(std::shared_ptr<Session> session);
+  ~GlVertexArray();
+
+  void Init();
+
+ private:
+  uint64_t id_;
+  std::weak_ptr<Session> session_;
+};
+
+}  // namespace zen::remote::server


### PR DESCRIPTION
## Context

Create vao object

## Summary

- [x] Create vertex array objects on both client and server side.

## How to check behavior

Use https://github.com/zigen-project/zen/pull/210 as well.

When execute zen-box, vertex array object will be created in Quest. You can check that by modifying the code to output the log.