### PR TITLE
fix deadlock on termination

### DIFF
--- a/src/server/session.cc
+++ b/src/server/session.cc
@@ -166,6 +166,9 @@ Session::StartPingThread()
     finish_cond.wait_for(
         lock, std::chrono::microseconds(100), [&finished] { return finished; });
 
+    lock.unlock();
+
+    context.TryCancel();
     cq->Shutdown();
 
     completion_thread.join();


### PR DESCRIPTION
## Context

Deadlock happened when terminating. This pull request fix that.

## Summary

- [x] Release lock appropriately.

## How to check behavior

Check that the deadlock doesn't happen.