### PR TITLE
fix https://github.com/zigen-project/zen-remote/issues/20

### DIFF
--- a/src/client/gl-base-technique.h
+++ b/src/client/gl-base-technique.h
@@ -9,6 +9,23 @@ class AtomicCommandQueue;
 struct Camera;
 
 class GlBaseTechnique final : public IResource {
+  enum class DrawMethod {
+    kArrays,
+  };
+
+  union DrawArgs {
+    struct {
+      uint32_t mode;
+      int32_t count;
+      int32_t first;
+    } arrays;
+  };
+
+  struct RenderingState {
+    DrawArgs draw_args;
+    DrawMethod draw_method;
+  };
+
  public:
   DISABLE_MOVE_AND_COPY(GlBaseTechnique);
   GlBaseTechnique() = delete;
@@ -30,18 +47,6 @@ class GlBaseTechnique final : public IResource {
   const uint64_t id_;
   AtomicCommandQueue *update_rendering_queue_;
 
-  enum class DrawMethod {
-    kArrays,
-  };
-
-  union DrawArgs {
-    struct {
-      uint32_t mode;
-      int32_t count;
-      int32_t first;
-    } arrays;
-  };
-
   struct {
     bool damaged = false;
 
@@ -49,10 +54,7 @@ class GlBaseTechnique final : public IResource {
     DrawMethod draw_method;
   } pending_;
 
-  struct {
-    DrawArgs draw_args;
-    DrawMethod draw_method;
-  } rendering_;
+  std::shared_ptr<RenderingState> rendering_;
 };
 
 }  // namespace zen::remote::client

--- a/src/client/gl-buffer.h
+++ b/src/client/gl-buffer.h
@@ -8,6 +8,12 @@ namespace zen::remote::client {
 class AtomicCommandQueue;
 
 class GlBuffer final : public IResource {
+  struct RenderingState {
+    GLuint buffer_id = 0;
+
+    uint32_t target;
+  };
+
  public:
   DISABLE_MOVE_AND_COPY(GlBuffer);
   GlBuffer() = delete;
@@ -42,23 +48,19 @@ class GlBuffer final : public IResource {
     bool data_damaged = false;
   } pending_;
 
-  struct {
-    GLuint buffer_id = 0;
-
-    uint32_t target;
-  } rendering_;
+  std::shared_ptr<RenderingState> rendering_;
 };
 
 inline GLuint
 GlBuffer::buffer_id()
 {
-  return rendering_.buffer_id;
+  return rendering_->buffer_id;
 }
 
 inline uint32_t
 GlBuffer::target()
 {
-  return rendering_.target;
+  return rendering_->target;
 }
 
 }  // namespace zen::remote::client

--- a/src/client/rendering-unit.cc
+++ b/src/client/rendering-unit.cc
@@ -9,11 +9,20 @@ namespace zen::remote::client {
 
 RenderingUnit::RenderingUnit(
     uint64_t id, AtomicCommandQueue* update_rendering_queue)
-    : id_(id), update_rendering_queue_(update_rendering_queue)
+    : id_(id),
+      update_rendering_queue_(update_rendering_queue),
+      rendering_(new RenderingState())
 {
 }
 
-RenderingUnit::~RenderingUnit() {}
+RenderingUnit::~RenderingUnit()
+{
+  auto command = CreateCommand([rendering = rendering_](bool /*cancel*/) {});
+
+  rendering_.reset();
+
+  update_rendering_queue_->Push(std::move(command));
+}
 
 void
 RenderingUnit::Commit()
@@ -22,14 +31,14 @@ RenderingUnit::Commit()
     gl_base_technique->Commit();
   }
 
-  auto command = CreateCommand(
-      [technique = pending_.gl_base_technique, this](bool cancel) {
-        if (cancel) {
-          return;
-        }
+  auto command = CreateCommand([technique = pending_.gl_base_technique,
+                                   rendering = rendering_](bool cancel) {
+    if (cancel) {
+      return;
+    }
 
-        rendering_.gl_base_technique = technique;
-      });
+    rendering->gl_base_technique = technique;
+  });
 
   update_rendering_queue_->Push(std::move(command));
 }
@@ -44,7 +53,7 @@ RenderingUnit::SetGlBaseTechnique(
 void
 RenderingUnit::Render(Camera* camera)
 {
-  if (auto gl_base_technique = rendering_.gl_base_technique.lock()) {
+  if (auto gl_base_technique = rendering_->gl_base_technique.lock()) {
     gl_base_technique->Render(camera);
   }
 }

--- a/src/client/rendering-unit.h
+++ b/src/client/rendering-unit.h
@@ -11,6 +11,10 @@ class AtomicCommandQueue;
 struct Camera;
 
 class RenderingUnit final : public IResource {
+  struct RenderingState {
+    std::weak_ptr<GlBaseTechnique> gl_base_technique;
+  };
+
  public:
   DISABLE_MOVE_AND_COPY(RenderingUnit);
   RenderingUnit() = delete;
@@ -36,9 +40,7 @@ class RenderingUnit final : public IResource {
     std::weak_ptr<GlBaseTechnique> gl_base_technique;
   } pending_;
 
-  struct {
-    std::weak_ptr<GlBaseTechnique> gl_base_technique;
-  } rendering_;
+  std::shared_ptr<RenderingState> rendering_;  // nonnull
 };
 
 }  // namespace zen::remote::client

--- a/src/client/virtual-object.h
+++ b/src/client/virtual-object.h
@@ -10,10 +10,16 @@ class RenderingUnit;
 class AtomicCommandQueue;
 
 class VirtualObject final : public IResource {
+  struct RenderingState {
+    bool commited = false;
+    std::list<std::weak_ptr<RenderingUnit>> rendering_units_;
+  };
+
  public:
   DISABLE_MOVE_AND_COPY(VirtualObject);
   VirtualObject() = delete;
   VirtualObject(uint64_t id, AtomicCommandQueue *update_rendering_queue);
+  ~VirtualObject();
 
   /** Used in the update thread */
   void Commit();
@@ -37,16 +43,13 @@ class VirtualObject final : public IResource {
     std::list<std::weak_ptr<RenderingUnit>> rendering_units_;
   } pending_;
 
-  struct {
-    bool commited = false;
-    std::list<std::weak_ptr<RenderingUnit>> rendering_units_;
-  } rendering_;
+  std::shared_ptr<RenderingState> rendering_;  // nonnull
 };
 
 inline bool
 VirtualObject::commited()
 {
-  return rendering_.commited;
+  return rendering_->commited;
 }
 
 }  // namespace zen::remote::client


### PR DESCRIPTION
## Context

https://github.com/zigen-project/zen-remote/issues/20

## Summary

- [x] Make rendering state shared_ptr, and accessing the pointer **including destruction** performed only in the rendering thread.

## How to check behavior

No behavioral change is made.