### PR TITLE
enable gl_base_technique to bind vertex array

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(
   LANGUAGES C CXX
   HOMEPAGE_URL https://github.com/zigen-project/zen-remote
   DESCRIPTION "Library for ZEN to communicate with devices over a network"
-  VERSION 0.1.0.14
+  VERSION 0.1.0.15
 )
 
 set(CMAKE_CXX_STANDARD 17)

--- a/include/zen-remote/server/gl-base-technique.h
+++ b/include/zen-remote/server/gl-base-technique.h
@@ -9,6 +9,8 @@ namespace zen::remote::server {
 struct IGlBaseTechnique {
   virtual ~IGlBaseTechnique() = default;
 
+  virtual void BindVertexArray(uint64_t vertex_array_id) = 0;
+
   virtual void GlDrawArrays(uint32_t mode, int32_t first, uint32_t count) = 0;
 
   virtual uint64_t id() = 0;

--- a/include/zen-remote/server/gl-vertex-array.h
+++ b/include/zen-remote/server/gl-vertex-array.h
@@ -16,6 +16,8 @@ struct IGlVertexArray {
   virtual void GlVertexAttribPointer(uint32_t index, int32_t size,
       uint32_t type, bool normalized, int32_t stride, uint64_t offset,
       uint64_t gl_buffer_id) = 0;
+
+  virtual uint64_t id() = 0;
 };
 
 std::unique_ptr<IGlVertexArray> CreateGlVertexArray(

--- a/protos/gl-base-technique.proto
+++ b/protos/gl-base-technique.proto
@@ -10,6 +10,8 @@ service GlBaseTechniqueService
 
   rpc Delete(DeleteResourceRequest) returns (EmptyResponse);
 
+  rpc BindVertexArray(BindVertexArrayRequest) returns (EmptyResponse);
+
   rpc GlDrawArrays(GlDrawArraysRequest) returns (EmptyResponse);
 }
 
@@ -17,6 +19,12 @@ message NewGlBaseTechniqueRequest
 {
   uint64 id = 1;
   uint64 rendering_unit_id = 2;
+}
+
+message BindVertexArrayRequest
+{
+  uint64 id = 1;
+  uint64 vertex_array_id = 2;
 }
 
 message GlDrawArraysRequest

--- a/src/client/gl-base-technique.h
+++ b/src/client/gl-base-technique.h
@@ -5,6 +5,7 @@
 
 namespace zen::remote::client {
 
+class GlVertexArray;
 class AtomicCommandQueue;
 struct Camera;
 
@@ -25,6 +26,7 @@ class GlBaseTechnique final : public IResource {
   struct RenderingState {
     DrawArgs draw_args;
     DrawMethod draw_method = DrawMethod::kNone;
+    std::weak_ptr<GlVertexArray> vertex_array;  // nullable
   };
 
  public:
@@ -35,6 +37,9 @@ class GlBaseTechnique final : public IResource {
 
   /** Used in the update thread */
   void Commit();
+
+  /** Used in the update thread */
+  void Bind(std::weak_ptr<GlVertexArray> vertex_array);
 
   /** Used in the update thread */
   void GlDrawArrays(uint32_t mode, int32_t first, uint32_t count);
@@ -49,10 +54,12 @@ class GlBaseTechnique final : public IResource {
   AtomicCommandQueue *update_rendering_queue_;
 
   struct {
-    bool damaged = false;
-
     DrawArgs draw_args;
     DrawMethod draw_method = DrawMethod::kNone;
+    bool draw_method_damaged = false;
+
+    std::weak_ptr<GlVertexArray> vertex_array;  // nullable
+    bool vertex_array_damaged = false;
   } pending_;
 
   std::shared_ptr<RenderingState> rendering_;

--- a/src/client/gl-vertex-array.cc
+++ b/src/client/gl-vertex-array.cc
@@ -129,8 +129,6 @@ GlVertexArray::GlVertexAttribPointer(uint32_t index, int32_t size,
   (*result).second.filled = true;
   (*result).second.damaged = true;
 
-  LOG_INFO("index: %u, size: %d", index, size);
-
   pending_.damaged = true;
 }
 

--- a/src/client/service/gl-base-technique.cc
+++ b/src/client/service/gl-base-technique.cc
@@ -30,6 +30,11 @@ GlBaseTechniqueServiceImpl::Listen(
       completion_queue, remote_);
 
   AsyncSessionServiceCaller<
+      &GlBaseTechniqueService::AsyncService::RequestBindVertexArray,
+      &GlBaseTechniqueServiceImpl::BindVertexArray>::Listen(&async_, this,
+      completion_queue, remote_);
+
+  AsyncSessionServiceCaller<
       &GlBaseTechniqueService::AsyncService::RequestGlDrawArrays,
       &GlBaseTechniqueServiceImpl::GlDrawArrays>::Listen(&async_, this,
       completion_queue, remote_);
@@ -58,6 +63,20 @@ GlBaseTechniqueServiceImpl::Delete(grpc::ServerContext* /*context*/,
 {
   auto pool = remote_->session_manager()->current()->pool();
   pool->gl_base_techniques()->ScheduleRemove(request->id());
+  return grpc::Status::OK;
+}
+
+grpc::Status
+GlBaseTechniqueServiceImpl::BindVertexArray(grpc::ServerContext* /*context*/,
+    const BindVertexArrayRequest* request, EmptyResponse* /*response*/)
+{
+  auto pool = remote_->session_manager()->current()->pool();
+
+  auto base_technique = pool->gl_base_techniques()->Get(request->id());
+  auto vertex_array = pool->gl_vertex_arrays()->Get(request->vertex_array_id());
+
+  base_technique->Bind(vertex_array);
+
   return grpc::Status::OK;
 }
 

--- a/src/client/service/gl-base-technique.h
+++ b/src/client/service/gl-base-technique.h
@@ -28,6 +28,9 @@ class GlBaseTechniqueServiceImpl final : public GlBaseTechniqueService::Service,
   grpc::Status Delete(grpc::ServerContext* context,
       const DeleteResourceRequest* request, EmptyResponse* response) override;
 
+  grpc::Status BindVertexArray(grpc::ServerContext* context,
+      const BindVertexArrayRequest* request, EmptyResponse* response) override;
+
   grpc::Status GlDrawArrays(grpc::ServerContext* context,
       const GlDrawArraysRequest* request, EmptyResponse* response) override;
 

--- a/src/server/gl-base-technique.cc
+++ b/src/server/gl-base-technique.cc
@@ -54,6 +54,43 @@ GlBaseTechnique::Init(uint64_t rendering_unit_id)
 }
 
 void
+GlBaseTechnique::BindVertexArray(uint64_t vertex_array_id)
+{
+  auto session = session_.lock();
+  if (!session) return;
+
+  auto context_raw = new SerialRequestContext(session.get());
+
+  auto job = CreateJob([id = id_, connection = session->connection(),
+                           context_raw, grpc_queue = session->grpc_queue(),
+                           vertex_array_id](bool cancel) {
+    auto context = std::unique_ptr<grpc::ClientContext>(context_raw);
+    if (cancel) {
+      return;
+    }
+
+    auto stub = GlBaseTechniqueService::NewStub(connection->grpc_channel());
+
+    auto caller = new AsyncGrpcCaller<
+        &GlBaseTechniqueService::Stub::PrepareAsyncBindVertexArray>(
+        std::move(stub), std::move(context),
+        [connection](EmptyResponse* /*response*/, grpc::Status* status) {
+          if (!status->ok() && status->error_code() != grpc::CANCELLED) {
+            LOG_WARN("Failed to call remote GlBaseTechnique::BindVertexArray");
+            connection->NotifyDisconnection();
+          }
+        });
+
+    caller->request()->set_id(id);
+    caller->request()->set_vertex_array_id(vertex_array_id);
+
+    grpc_queue->Push(std::unique_ptr<AsyncGrpcCallerBase>(caller));
+  });
+
+  session->job_queue()->Push(std::move(job));
+}
+
+void
 GlBaseTechnique::GlDrawArrays(uint32_t mode, int32_t first, uint32_t count)
 {
   auto session = session_.lock();

--- a/src/server/gl-base-technique.h
+++ b/src/server/gl-base-technique.h
@@ -15,7 +15,11 @@ class GlBaseTechnique final : public IGlBaseTechnique {
   ~GlBaseTechnique();
 
   void Init(uint64_t rendering_unit_id);
+
+  void BindVertexArray(uint64_t vertex_array_id) override;
+
   void GlDrawArrays(uint32_t mode, int32_t first, uint32_t count) override;
+
   uint64_t id() override;
 
  private:

--- a/src/server/gl-vertex-array.cc
+++ b/src/server/gl-vertex-array.cc
@@ -212,6 +212,12 @@ GlVertexArray::~GlVertexArray()
   session->job_queue()->Push(std::move(job));
 }
 
+uint64_t
+GlVertexArray::id()
+{
+  return id_;
+}
+
 std::unique_ptr<IGlVertexArray>
 CreateGlVertexArray(std::shared_ptr<ISession> session)
 {

--- a/src/server/gl-vertex-array.h
+++ b/src/server/gl-vertex-array.h
@@ -24,6 +24,8 @@ class GlVertexArray final : public IGlVertexArray {
       bool normalized, int32_t stride, uint64_t offset,
       uint64_t gl_buffer_id) override;
 
+  uint64_t id() override;
+
  private:
   uint64_t id_;
   std::weak_ptr<Session> session_;


### PR DESCRIPTION
## Context

Enable gl_base_technique to bind vertex array object.
By pull request, glBuffer will be able to be committed in the client side. 
(Chain connected!: virtual object → rendering unit → gl_base_technique → vertex_array → gl_buffer)

## Summary

- [x] Enable gl_base_technique to bind vertex array.

