### PR TITLE
temporarily implement rendering funciton for development

### DIFF
--- a/src/client/gl-vertex-array.h
+++ b/src/client/gl-vertex-array.h
@@ -47,6 +47,9 @@ class GlVertexArray final : public IResource {
 
   uint64_t id() override;
 
+  /** Used in the rendering thread */
+  inline GLuint vertex_array_id();
+
  private:
   const uint64_t id_;
   AtomicCommandQueue *update_rendering_queue_;
@@ -58,5 +61,11 @@ class GlVertexArray final : public IResource {
 
   std::shared_ptr<RenderingState> rendering_;
 };
+
+inline GLuint
+GlVertexArray::vertex_array_id()
+{
+  return rendering_->vertex_array_id;
+}
 
 }  // namespace zen::remote::client


### PR DESCRIPTION
## Context

Now we implemented data transferring of minimum assets to render something.
(buffer, vao, rendering unit, base technique, virtual object)

This pull request implement rendering function to show sample usage of these assets and to check that those assets are properly transferred.

## Summary

- [x] Implement sample rendering function to be deleted in the future.

## How to check behavior

Start zen-box, you will see lines in Quest.