### PR TITLE
Fix installation directory's path configured in CMake

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -47,7 +47,7 @@ configure_file(zen-remote-client.pc.in zen-remote-client.pc @ONLY)
 
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/zen-remote-client.pc
-  DESTINATION lib/pkgconfig
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
 
 install(

--- a/src/client/zen-remote-client.pc.in
+++ b/src/client/zen-remote-client.pc.in
@@ -1,11 +1,11 @@
-prefix="@CMAKE_INSTALL_PREFIX@"
-exec_prefix="${prefix}"
-libdir="${prefix}/lib"
-includedir="${prefix}/include"
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: ZEN remote client
 Description: @CMAKE_PROJECT_DESCRIPTION@ - client
 URL: @CMAKE_PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
-Libs: -L"${libdir}" -lzen-remote-client
-Cflags: -I"${includedir}"
+Libs: -L${libdir} -lzen-remote-client
+Cflags: -I${includedir}

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -36,7 +36,7 @@ configure_file(zen-remote-server.pc.in zen-remote-server.pc @ONLY)
 
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/zen-remote-server.pc
-  DESTINATION lib/pkgconfig
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
 
 install(

--- a/src/server/zen-remote-server.pc.in
+++ b/src/server/zen-remote-server.pc.in
@@ -1,11 +1,11 @@
-prefix="@CMAKE_INSTALL_PREFIX@"
-exec_prefix="${prefix}"
-libdir="${prefix}/lib"
-includedir="${prefix}/include"
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: ZEN remote server
 Description: @CMAKE_PROJECT_DESCRIPTION@ - server
 URL: @CMAKE_PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
-Libs: -L"${libdir}" -lzen-remote-server
-Cflags: -I"${includedir}"
+Libs: -L${libdir} -lzen-remote-server
+Cflags: -I${includedir}


### PR DESCRIPTION
## Context

>The current pkgconfig settings do not fully reflect the installation directory configured in CMake.

ref: #8 


## Summary

<!--
Please write what you did here. If you have made changes to the appearance, it
would be helpful to include images as well.
-->

Changed pkgconfig settings to refer to the actual CMake installation path.
Also, rewrote pkgconfig settings based on the Metadata File Syntax example in [pkg-config(1) - Linux man page
](https://linux.die.net/man/1/pkg-config).

- For the explanation of `CMAKE_INSTALL_LIBDIR` and `CMAKE_INSTALL_INCLUDEDIR`, refer to the following link
  - https://cmake.org/cmake/help/latest/command/install.html
- For the difference b/w `prefix` and `exec_prefix`, see the following link
  - https://www.gnu.org/prep/standards/html_node/Directory-Variables.html


