### PR TITLE
enable to disable session

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(
   LANGUAGES C CXX
   HOMEPAGE_URL https://github.com/zigen-project/zen-remote
   DESCRIPTION "Library for ZEN to communicate with devices over a network"
-  VERSION 0.1.0.20
+  VERSION 0.1.0.21
 )
 
 set(CMAKE_CXX_STANDARD 17)

--- a/include/zen-remote/client/remote.h
+++ b/include/zen-remote/client/remote.h
@@ -11,7 +11,11 @@ namespace zen::remote::client {
 struct IRemote {
   virtual ~IRemote() = default;
 
-  virtual void Start() = 0;
+  virtual void StartGrpcServer() = 0;
+
+  virtual void EnableSession() = 0;
+
+  virtual void DisableSession() = 0;
 
   virtual void UpdateScene() = 0;  // deprecated
 

--- a/include/zen-remote/server/session.h
+++ b/include/zen-remote/server/session.h
@@ -16,6 +16,9 @@ namespace zen::remote::server {
 struct ISession {
   virtual ~ISession() = default;
 
+  /**
+   * @return false when failed. Do not reuse the instance
+   */
   virtual bool Connect(std::shared_ptr<IPeer> peer) = 0;
 
   Signal<void()> on_disconnect;

--- a/src/client/gl-base-technique.cc
+++ b/src/client/gl-base-technique.cc
@@ -329,8 +329,6 @@ GlBaseTechnique::Render(Camera* camera, const glm::mat4& model)
   } else if (rendering_->draw_method == DrawMethod::kElements) {
     auto args = rendering_->draw_args.elements;
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, element_array_buffer->buffer_id());
-    LOG_INFO(
-        "glBindBuffer GL_ELEMENT_ARRAY %d", element_array_buffer->buffer_id());
     glDrawElements(args.mode, args.count, args.type, (void*)args.offset);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
   }

--- a/src/client/remote.cc
+++ b/src/client/remote.cc
@@ -11,12 +11,22 @@ namespace zen::remote::client {
 Remote::Remote(std::unique_ptr<ILoop> loop) : loop_(std::move(loop)) {}
 
 void
-Remote::Start()
+Remote::StartGrpcServer()
 {
-  session_manager_.Start();
-
   grpc_server_ = std::make_unique<GrpcServer>("0.0.0.0", kGrpcPort, this);
   grpc_server_->Start();
+}
+
+void
+Remote::EnableSession()
+{
+  session_manager_.EnableSession();
+}
+
+void
+Remote::DisableSession()
+{
+  session_manager_.DisableSession();
 }
 
 void

--- a/src/client/remote.h
+++ b/src/client/remote.h
@@ -15,7 +15,11 @@ class Remote : public IRemote {
   Remote() = delete;
   Remote(std::unique_ptr<ILoop> loop);
 
-  void Start() override;
+  void StartGrpcServer() override;
+
+  void EnableSession() override;
+
+  void DisableSession() override;
 
   /** Call only once before rendering for multiple cameras. */
   void UpdateScene() override;

--- a/src/client/service/session.cc
+++ b/src/client/service/session.cc
@@ -33,7 +33,10 @@ SessionServiceImpl::New(grpc::ServerContext* /*context*/,
 
   response->set_id(id);
 
-  return grpc::Status::OK;
+  if (id == 0)
+    return grpc::Status(grpc::ABORTED, "Failed to create a session");
+  else
+    return grpc::Status::OK;
 }
 
 }  // namespace zen::remote::client::service


### PR DESCRIPTION
## Context

Session should be disabled temporary by the client side, for example when the user put off the HMD and the HMD is going to sleep. This pull request makes it possible to disable session.

## Summary

- [x] Fix client side API.

## How to check behavior

See https://github.com/zigen-project/zen-oculus-display-system/pull/26 