### PR TITLE
naive congestion controll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(
   LANGUAGES C CXX
   HOMEPAGE_URL https://github.com/zigen-project/zen-remote
   DESCRIPTION "Library for ZEN to communicate with devices over a network"
-  VERSION 0.1.0.23
+  VERSION 0.1.0.24
 )
 
 set(CMAKE_CXX_STANDARD 17)

--- a/include/zen-remote/server/session.h
+++ b/include/zen-remote/server/session.h
@@ -21,6 +21,8 @@ struct ISession {
    */
   virtual bool Connect(std::shared_ptr<IPeer> peer) = 0;
 
+  virtual int32_t GetPendingGrpcQueueCount() = 0;
+
   Signal<void()> on_disconnect;
 };
 

--- a/src/server/async-grpc-queue.cc
+++ b/src/server/async-grpc-queue.cc
@@ -17,6 +17,8 @@ AsyncGrpcQueue::Push(std::unique_ptr<AsyncGrpcCallerBase> caller)
   auto caller_raw = caller.release();
 
   caller_raw->Start(cq_.get());
+
+  pending_count_++;
 }
 
 void
@@ -24,7 +26,7 @@ AsyncGrpcQueue::Start()
 {
   if (thread_.joinable()) return;
 
-  thread_ = std::thread([cq = cq_] {
+  thread_ = std::thread([cq = cq_, this] {
     void *tag;
     bool ok = false;
 
@@ -34,6 +36,8 @@ AsyncGrpcQueue::Start()
       caller->Finish();
 
       delete caller;
+
+      pending_count_--;
     }
   });
 }

--- a/src/server/async-grpc-queue.h
+++ b/src/server/async-grpc-queue.h
@@ -18,9 +18,18 @@ class AsyncGrpcQueue {
 
   void Terminate();
 
+  inline uint32_t pending_count();
+
  private:
   std::thread thread_;
   std::shared_ptr<grpc::CompletionQueue> cq_;
+  std::atomic_int32_t pending_count_ = 0;
 };
+
+inline uint32_t
+AsyncGrpcQueue::pending_count()
+{
+  return pending_count_.load();
+}
 
 }  // namespace zen::remote::server

--- a/src/server/session.cc
+++ b/src/server/session.cc
@@ -89,6 +89,12 @@ Session::Connect(std::shared_ptr<IPeer> peer)
   return true;
 }
 
+int32_t
+Session::GetPendingGrpcQueueCount()
+{
+  return grpc_queue_->pending_count();
+}
+
 /**
  * Excuse: This is a stopgap implementation to prioritize other parts of the
  * development. It can use keepalive of gRPC or be more concise implementation.

--- a/src/server/session.h
+++ b/src/server/session.h
@@ -26,6 +26,8 @@ class Session final : public ISession {
   // TODO: make this async
   bool Connect(std::shared_ptr<IPeer> peer) override;
 
+  int32_t GetPendingGrpcQueueCount() override;
+
   uint64_t NewSerial(SerialType type);
 
   inline JobQueue* job_queue();


### PR DESCRIPTION
## Context

We need congestion control.

## Summary

Enable zen to get the number of pending elements in gRPC network queue.

## How to check behavior

https://github.com/zigen-project/zen/pull/269