### PR TITLE
optimize ci

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,19 +17,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install meson libglew-dev
 
-      - name: Clone grpc-dev
-        uses: actions/checkout@v2
-        with:
-          repository: zigen-project/grpc-dev
-          path: grpc-dev
-          submodules: recursive
-          ref: 'v1.49.1' 
-      
-      - name: Build grpc-dev
-        working-directory: ./grpc-dev
+      - run: mkdir -p grpc-dev
+
+      - name: Download grpc-dev
         run: |
-          touch local.mk
-          make native
+          curl -L https://github.com/zigen-project/grpc-dev/releases/download/0.0.1/grpc-dev-refs.heads.main-github-host.zip -o grpc-dev.zip
+          unzip grpc-dev.zip
+        working-directory: ./grpc-dev
 
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Context

CI is very slow due to grpc-dev compile

## Summary

Use prebuilt grpc-dev

## How to check behavior

Build time is reduced.