### PR TITLE
add MVP matrices respectively

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(
   LANGUAGES C CXX
   HOMEPAGE_URL https://github.com/zigen-project/zen-remote
   DESCRIPTION "Library for ZEN to communicate with devices over a network"
-  VERSION 0.1.0.27
+  VERSION 0.1.0.28
 )
 
 set(CMAKE_CXX_STANDARD 17)

--- a/include/zen-remote/client/camera.h
+++ b/include/zen-remote/client/camera.h
@@ -5,7 +5,11 @@ namespace zen::remote::client {
 struct Camera {
   struct {
     float x0, y0, z0, w0, x1, y1, z1, w1, x2, y2, z2, w2, x3, y3, z3, w3;
-  } vp;  // col major mat4
+  } view;  // col major mat4
+
+  struct {
+    float x0, y0, z0, w0, x1, y1, z1, w1, x2, y2, z2, w2, x3, y3, z3, w3;
+  } projection;  // col major mat4
 };
 
 }  // namespace zen::remote::client

--- a/src/client/gl-base-technique.cc
+++ b/src/client/gl-base-technique.cc
@@ -236,9 +236,27 @@ void
 GlBaseTechnique::ApplyUniformVariables(
     GLuint program_id, Camera* camera, const glm::mat4& model)
 {
-  glm::mat4 vp;
-  std::memcpy(&vp, &camera->vp, sizeof(glm::mat4));
+  glm::mat4 view;
+  std::memcpy(&view, &camera->view, sizeof(glm::mat4));
+
+  glm::mat4 projection;
+  std::memcpy(&projection, &camera->projection, sizeof(glm::mat4));
+
+  glm::mat4 vp = projection * view;
   glm::mat4 mvp = vp * model;
+
+  auto model_location = glGetUniformLocation(program_id, "zModel");
+  glUniformMatrix4fv(model_location, 1, GL_FALSE, glm::value_ptr(model));
+
+  auto view_location = glGetUniformLocation(program_id, "zView");
+  glUniformMatrix4fv(view_location, 1, GL_FALSE, glm::value_ptr(view));
+
+  auto projection_location = glGetUniformLocation(program_id, "zProjection");
+  glUniformMatrix4fv(
+      projection_location, 1, GL_FALSE, glm::value_ptr(projection));
+
+  auto vp_location = glGetUniformLocation(program_id, "zVP");
+  glUniformMatrix4fv(vp_location, 1, GL_FALSE, glm::value_ptr(vp));
 
   auto mvp_location = glGetUniformLocation(program_id, "zMVP");
   glUniformMatrix4fv(mvp_location, 1, GL_FALSE, glm::value_ptr(mvp));


### PR DESCRIPTION
## Context

We need model / view / projection matrices respectively to render shaded scene

## Summary

Add `zModel`, `zView`, `zProjection`, `zVP`

## How to check behavior

<!--
If you added a new feature, please write a way for other developers to easily
check the behavior you have changed or added so that they can catch up with the
changes.
-->
