### PR TITLE
cast uniform location to uint32_t

### DIFF
--- a/src/client/gl-base-technique.cc
+++ b/src/client/gl-base-technique.cc
@@ -142,7 +142,8 @@ GlBaseTechnique::Commit()
 
             auto [iterator, newly_inserted] =
                 rendering->uniform_variables.insert(
-                    std::pair<uint32_t, UniformVariable>{location, {}});
+                    std::pair<uint32_t, UniformVariable>{
+                        static_cast<uint32_t>(location), {}});
 
             if (newly_inserted) {
               (*iterator).second.location = location;
@@ -301,7 +302,7 @@ void
 GlBaseTechnique::SetupTextures(GLuint program_id)
 {
   for (auto it = rendering_->texture_bindings.begin();
-       it != rendering_->texture_bindings.end();) {
+      it != rendering_->texture_bindings.end();) {
     auto& texture_binding = (*it).second;
     uint32_t binding = (*it).first;
 


### PR DESCRIPTION
## Context

Currently build fails by the following error:

```
/home/watasuke/program/zwin/zen-remote/src/client/gl-base-technique.cc:145:58: error: non-constant-expression cannot be narrowed from type 'int32_t' (aka 'int') to 'unsigned int' in initializer list [-Wc++11-narrowing-const-reference]
  145 |                     std::pair<uint32_t, UniformVariable>{location, {}});
      |                                                          ^~~~~~~~
```

## Summary

cast `location` to uint32_t; `location` is positive number on this (changed) line, so casting is safe

## How to check the behavior

Build succeeds without errors